### PR TITLE
Adding Travis config with htmlproofer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: ruby
+rvm:
+  - 2.1
+script:
+  - bundle exec jekyll build
+  - bundle exec htmlproof ./_site --only-4xx --check-html
+branches:
+  only:
+  - master
+  - gh-pages
+env:
+  global:
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer


### PR DESCRIPTION
This will cause Travis to run htmlproofer to check for well-formed HTML
and valid links on every build.

Note that this checks for broken links, which don't exist in this repo yet, but do exist on our legacy site, so if we start mass copying over content, this check will fail when we copy something with a broken link. We can either fix the broken links as we go or disable the link checking (or just external link checking) until we port all the content, then fix all the links at the end. I prefer the former, but it's up to the people more active in the porting work.