### PR TITLE
NDT Tools Page Addition

### DIFF
--- a/_layouts/ndt-test.html
+++ b/_layouts/ndt-test.html
@@ -1,0 +1,34 @@
+
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf8">
+	<title>{{ page.title }}</title>
+	<style>
+		#ndt-iframe {
+			width: 720px;
+			height: 480px;
+			border: none;
+		}
+	</style>
+</head>
+<body>
+<script>
+var	mlabNsUrl = 'https://mlab-ns.appspot.com/ndt?format=json';
+var xhr = new XMLHttpRequest();
+xhr.onreadystatechange = function () {
+  if (xhr.readyState === 4) {
+    if (xhr.status === 200) {
+      var response = JSON.parse(xhr.responseText);
+      var ndtIframe = document.createElement('iframe');
+      ndtIframe.src = response.url;
+      ndtIframe.setAttribute('id', 'ndt-iframe');
+      document.body.appendChild(ndtIframe);
+    }
+  }
+};
+xhr.open("GET", mlabNsUrl, true);
+xhr.send();
+</script>
+</body>
+</html>

--- a/_pages/ndt-ws.md
+++ b/_pages/ndt-ws.md
@@ -1,0 +1,5 @@
+---
+layout: ndt-test
+permalink: /p/ndt-ws.html
+title: "NDT Test"
+---

--- a/_pages/tools/ndt.md
+++ b/_pages/tools/ndt.md
@@ -1,6 +1,53 @@
 ---
 layout: page
 permalink: /tools/ndt/
+title: "NDT (Network Diagnostic Test)"
+breadcrumb: tests
 ---
 
-NDT content here
+# NDT (Network Diagnostic Test)
+
+NDT (Network Diagnostic Tool) provides a sophisticated speed and
+diagnostic test suitable for both the novice and the network researcher.
+Not only does NDT report upload and download speeds, it also attempts to
+determine what problems limited speeds, and provides details diagnostic
+reporting on what it found. While the diagnostic messages are most
+useful for expert users, they can also help novice users by allowing
+them to provide detailed trouble reports to their network administrator.
+
+## Run NDT
+
+There are two supported ways to run an NDT test: via this web page below
+or via a Unix command-line tool.
+
+NOTE: if the test does not run or takes longer than 60 seconds, please
+read the [FAQ entry](http://measurementlab.net/faq) for "troubleshooting
+the NDT speed test".
+
+<p><iframe src="{{ site.baseurl }}/p/ndt-ws.html" width="750" height="500" align="middle"></iframe></p>
+
+**[Download command line client](https://code.google.com/p/ndt/source/){:.download-link .is-plain}**
+
+**Data** collected by NDT is available...
+
+-   in raw format at <https://storage.cloud.google.com/m-lab/ndt>
+-   via an SQL interface
+    (see <https://github.com/m-lab/mlab-wikis/blob/master/BigQueryMLabDataset.md>).
+-   Visualized in [Public Data
+    Explorer](https://www.google.com/publicdata/explore?ds=e9krd11m38onf_&ctype=m&strail=false&bcs=d&nselm=s&met_s=number_of_tests&scale_s=lin&ind_s=false&ifdim=country&hl=en_US&dl=en_US&ind=false&xMax=180&xMin=-180&yMax=-54.423985288271695&yMin=81.24033645136825&mapType=t&icfg&iconSize=0.5).
+-   Please cite this dataset as follows: **The MLab NDT Dataset,
+    &lt;date range used&gt;. http://measurementlab.net/tools/ndt**
+
+**Source code** is available at <http://code.google.com/p/ndt/source/>.
+
+**More information** at <http://code.google.com/p/ndt/>
+and <http://www.internet2.edu/performance/ndt/>.
+
+
+<div id="mcePasteBin"
+style="position: absolute; top: 0px; left: 0; background: red; width: 1px; height: 1px; overflow: hidden;"
+contenteditable="false">
+
+
+NOTE: if the test does not run or takes longer than 60 seconds,\
+please read the FAQ entry for "troubleshooting the NDT speed test".


### PR DESCRIPTION
**UPDATE** - This PR has now been rebased and can be reviewed/merged.
~~**Please NOTE** - This pull request builds upon previous PRs, specifically https://github.com/m-lab/m-lab.github.io/pull/20. Please don't merge until previous PRs are accepted and I've rebased.~~

A small pull request that features adding the content for the NDT Tools page.  

- This required the addition of the NDT Tester as well [http://www.measurementlab.net/p/ndt-ws.html](http://www.measurementlab.net/p/ndt-ws.html).  Used the same URL structure on current site, however, if any changes are required with this, just let me know!


**IMPORTANT** 
- A preview of this change can be previewed here: [http://andrew-m-lab.github.io/tools/ndt/](http://andrew-m-lab.github.io/tools/ndt/).
- You will notice that the NDT tool loads just fine using HTTP, however using HTTPS [https://andrew-m-lab.github.io/tools/ndt/](https://andrew-m-lab.github.io/tools/ndt/), the NDT is being blocked and will *NOT* load.  I made to ensure the references in the m-lab code is using HTTPS, but it looks like a reference in the NDT tool is not allowing HTTPS:
    - __Works__: [http://ndt.iupui.mlab1.iad01.measurement-lab.org:7123/](http://ndt.iupui.mlab1.iad01.measurement-lab.org:7123/)
    - __Doesn't Work__: [https://ndt.iupui.mlab1.iad01.measurement-lab.org:7123/](https://ndt.iupui.mlab1.iad01.measurement-lab.org:7123/)
<img width="856" alt="screen shot 2016-02-14 at 2 47 07 pm" src="https://cloud.githubusercontent.com/assets/2396774/13036019/642e038a-d32a-11e5-8e2b-ced0166aadbc.png">

