### PR TITLE
Content Migration - Mobile Performance Testing Tools Pages

### DIFF
--- a/_pages/tools/mobiperf.md
+++ b/_pages/tools/mobiperf.md
@@ -1,6 +1,16 @@
 ---
 layout: page
 permalink: /tools/mobiperf/
+title: "MobiPerf"
+breadcrumb: tests
 ---
 
-Mobiperf content here
+# MobiPerf
+
+MobiPerf is an open source application for measuring network performance on mobile platforms. You can measure your network's throughput and latency, as well as other useful network metrics. MobiPerf also performs measurements at regular intervals in the background.
+
+**Data** collected by MobiPerf in raw format at <https://storage.cloud.google.com/openmobiledata_public>.
+
+**Source code** is available at <https://github.com/Mobiperf/MobiPerf>.
+
+**More information** at <http://www.mobiperf.com/>.

--- a/_pages/tools/windrider.md
+++ b/_pages/tools/windrider.md
@@ -1,6 +1,16 @@
 ---
 layout: page
 permalink: /tools/windrider/
+title: "Windrider"
+breadcrumb: tests
 ---
 
-windrider content here
+# Windrider
+
+**Windrider has been decommissioned on 01/17/2013. The source code will be still available at the link provided below.**
+
+WindRider attempts to detect whether your mobile provider is performing application or service specific differentiation, such as prioritizing or slowing traffic to certain websites, applications, or content.
+
+**Source code** is available at <http://code.google.com/p/windrider/>.
+
+**More information** at <http://www.cs.northwestern.edu/~ict992/mobile.htm>.


### PR DESCRIPTION
Minor pull request that adds the content in markdown format for the following 2 mobile performance testing tools pages:

- /mobiperf/
- /windrider/

These pages can also be previewed [here](https://andrew-m-lab.github.io/tests/#performance-mobile).