### PR TITLE
Content Migration - State Testing Tools Pages

### DIFF
--- a/_pages/tools/paris_traceroute.md
+++ b/_pages/tools/paris_traceroute.md
@@ -1,6 +1,17 @@
 ---
 layout: page
 permalink: /tools/paris_traceroute/
+title: "Paris Traceroute"
+breadcrumb: tests
 ---
 
-paris_traceroute content here
+# Paris Traceroute
+
+Paris Traceroute collects paris-traceroute traces for every TCP connection used by the measurement tools running on the M-Lab platform. In addition to the existing route and topology data provided by regular traceroute, Paris Traceroute detects load balancing, noting when a transmission is split between two pathes. Like Sidestream, Paris Traceroute runs when another M-Lab tool makes a TCP connection with the platform.
+
+**Data** collected by paris-traceroute is available...
+
+- in raw format at <https://storage.cloud.google.com/m-lab/paris-traceroute>
+- via an SQL interface (see <https://github.com/m-lab/mlab-wikis/blob/master/BigQueryMLabDataset.md>).
+
+**More information** at [http://www.paris-traceroute.net](http://www.paris-traceroute.net/).

--- a/_pages/tools/reverse_traceroute.md
+++ b/_pages/tools/reverse_traceroute.md
@@ -1,6 +1,18 @@
 ---
 layout: page
 permalink: /tools/reverse_traceroute/
+title: "Reverse Traceroute"
+breadcrumb: tests
 ---
 
-reverse_traceroute content here
+# Reverse Traceroute
+
+Reverse traceroute measures the network path back to a user from selected network endpoints, and provides a rich source of information on network routing and topology.
+
+## [**Run Reserve Traceroute**](http://revtr.cs.washington.edu/)
+
+**Data** collected by Reverse traceroute in raw format at <https://storage.cloud.google.com/m-lab_revtr>.
+
+**Source code** is availabe at [https://github.com/drchoffnes/uw-prober](http://github.com/drchoffnes/uw-prober).
+
+**More information** at <http://www.cs.washington.edu/research/networking/astronomy/reverse-traceroute.html>.


### PR DESCRIPTION
Minor pull request that adds the content in markdown format for the following 2 mobile performance testing tools pages:

- /reverse_traceroute/
- /paris_traceroute/

These pages can also be previewed [here](https://andrew-m-lab.github.io/tests/#state).