### PR TITLE
Content Migration - Contact Page

### DIFF
--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -1,8 +1,10 @@
 ---
 layout: page
 permalink: /contact/
-title: "Contact"
+title: "Send us a message"
 breadcrumb: "about"
 ---
 
-Contact content here
+# Send us a message
+
+Have a question or comment about M-Lab?  Use the form below, or email us at [support@measurementlab.net](mailto:support@measurementlab.net). If you'd like to take part in a discussion with the broader M-Lab community then consider joining the [M-Lab Discuss email list](http://mail.measurementlab.net/mailman/listinfo/m-lab-discuss_measurementlab.net).


### PR DESCRIPTION
This is a very minor and quick update to put in the content for the /contact page.  It was determined the contact form on the current site is not necessary to convert over, so this contains just the top paragraph of content.