### PR TITLE
Adding Google Analytics Script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
   - 2.1
 script:
   - bundle exec jekyll build
-  - bundle exec htmlproof ./_site --only-4xx --check-html --file-ignore "/mlab_observatory/"
+  - bundle exec htmlproof ./_site --only-4xx --check-html --ignore-script-embeds --file-ignore "/mlab_observatory/"
 branches:
   only:
   - master

--- a/_data/header-footer-content.yml
+++ b/_data/header-footer-content.yml
@@ -79,3 +79,4 @@ footer:
     title: "Privacy Policy &amp; Acceptable Use Policy."
     link: "/privacy/"
     blurb: "All original material on Measurement Lab by New America Foundation is licensed under a <a href=\"http://creativecommons.org/licenses/by-nc-sa/3.0/us/\" target=\"_blank\">Creative Commons Attribution-Noncommercial-Share Alike 3.0 United States License.</a> M-Lab is a <a href=\"/who/\">collaborative effort</a> led by researchers in partnership with companies and other institutions."
+  mobile-error-msg: "For a fuller experience of data visualisation please visit our desktop site."

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -59,7 +59,7 @@
   ga('send', 'pageview');
 </script>
 
-<script id="mobile-iframe" type="text/template">
+<script id="mobile-iframe" type="text/template" data-proofer-ignore>
   <div class="error-msg visualisation-error">
     <h2 class="error-text">≈{{ footer.mobile-error-msg }}</h2>
   </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -46,4 +46,21 @@
     </div>
   </div>
 </footer>
+
 <script id="requirejs" src="{{ site.baseurl }}/js/libs/require.2.1.5.min.js" data-main="{{ site.baseurl }}/js/desktop.min" data-platform="desktop" data-ismobile="False"></script>
+
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-56251309-1', 'auto'); 
+  ga('send', 'pageview');
+</script>
+
+<script id="mobile-iframe" type="text/template">
+  <div class="error-msg visualisation-error">
+    <h2 class="error-text">≈{{ footer.mobile-error-msg }}</h2>
+  </div>
+</script>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -59,7 +59,7 @@
   ga('send', 'pageview');
 </script>
 
-<script id="mobile-iframe" type="text/template" data-proofer-ignore>
+<script id="mobile-iframe" type="text/template">
   <div class="error-msg visualisation-error">
     <h2 class="error-text">≈{{ footer.mobile-error-msg }}</h2>
   </div>


### PR DESCRIPTION
This pull request accomplishes the following:

- [x] - Noticed that google analytics was not previously included so adding that into the footer partial.

- [x] - Also noticed what looks like a script tag with embedded html that is supposed to be a fallback for mobile devices.  I wasn't able to see how this was implemented in the current site as browsing on my phone is not triggering that template to be shown.  I am adding that in however and in doing so needed to add an ignore-script-embed to the htmlproofer.  If we want to get rid of that script template then we can do that too...