### PR TITLE
Additional Documentation & Keywords Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Current Build Status is: [![Build Status](https://secure.travis-ci.org/m-lab/m-l
 | fonts | Contains the customized font libraries for the project. |
 | js | Contains the js libraries for the project. |
 | images | Contains all the image files for the site |
+| publications | Contains all the pdfs and docs that the site links too |
 
 ## Code Standards
 

--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -1,3 +1,17 @@
+{% comment %} 
+<!--
+  Breadcrumbs Feature
+
+  This partial can be included in any markdown file that needs accordion behavior.
+  Currently, this include has been referenced in the page, blog, blog-index, and blog-archive
+  layouts, but can be included in future and other layouts if deemed necessary.
+
+  If included for other pages/layouts, then it would be best to have breadcrumb and title 
+  in the page's frontmatter to display as the breadcrumbs.
+
+--> 
+{% endcomment %}
+
 {% assign header = site.data.header-footer-content.header %}
 
 {% comment %}<!-- Determine breadcrumb hierarchy for sub navs -->{% endcomment %}

--- a/_includes/carousel.html
+++ b/_includes/carousel.html
@@ -1,3 +1,26 @@
+{% comment %} 
+<!--
+  Carousel Feature
+
+  This partial can be included in any markdown file that needs carousel behavior.
+  Currently, this include has been referenced in the default layout and checks to 
+  see if a post has the carousel frontmatter key.  If it does, then it will include
+  the carousel feature into the page.
+
+  The format for frontmatter keys for carousels is as follows:
+  carousel: true
+  carousel-items:
+  - image: "image to show for each carousel item"
+    alt: "alt tag description for each image"
+    heading: "The heading to be shown on each carousel item"
+    caption: "Additional description text to be shown on each carousel item"
+    link: "If there is a URL that the carousel item should link too"
+    link-text: "The text that is clickable for each carousel item"
+  - repeat above items for however many carousel items should be shown
+  
+--> 
+{% endcomment %}
+
 <div class="carousel-section">
 	<i class="carousel-preloader"></i>
   <div class="carousel-ctn flexslider">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,3 +1,13 @@
+{% comment %} 
+<!--
+  Footer
+
+  This partial is included on every page except the observatory page to consistently
+  display the same footer on each page.
+  
+--> 
+{% endcomment %}
+
 {% assign footer = site.data.header-footer-content.footer %}
 
 <footer class="footer-section">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,9 +1,23 @@
+{% comment %} 
+<!--
+  HEAD
+
+  This partial is included on every page to consistently display the same HEAD tag 
+  information on each page.  
+  
+--> 
+{% endcomment %}
+
 <head>
 
   <!-- General metadata -->
   <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">  
-  <meta name="keywords" content="measurement, broadband measurement, internet measurement, open data, open science, performance test, speed test, throughput measurement" >
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+
+  {% if page.keywords %}
+  <meta name="keywords" content="{{ page.keywords }}" >
+  {% endif %}
+
   <meta name="viewport" content="width=1000px">
   <title>{% if page.page-title %}{{ page.page-title }} - {{ site.title }}{% elsif page.title %}{{ page.title }} - {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,3 +1,13 @@
+{% comment %} 
+<!--
+  Header
+
+  This partial is included on every page except the observatory page to consistently
+  display the same header on each page.
+  
+--> 
+{% endcomment %}
+
 {% assign header = site.data.header-footer-content.header %}
 {% assign current_page = page.url %}
 {% assign active_link = page.breadcrumb | append: "/" | prepend: "/" %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,7 +2,7 @@
 <!--
   Header
 
-  This partial is included on every page except the observatory page to consistently
+  This partial is included on every page except to consistently
   display the same header on each page.
   
 --> 

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -3,6 +3,7 @@ layout: homepage
 audience: homepage
 permalink: /
 title: "Home"
+keywords: "measurement, broadband measurement, internet measurement, open data, open science, performance test, speed test, throughput measurement"
 videoid: "RnIVMfBP4So"
 info-heading: "What is M-Lab?"
 info-subheading: "A short introduction"


### PR DESCRIPTION
This pull request identified one bug fix as well as builds on some documentation needs in the README file and several include files.

- [x] In a final review of the conversion process, one other item was identified as needing a fix.  This fix was for the meta keywords tag.  On the current site, the keywords meta tag is only found on the home page, however, on the Jekyll site a mistake was hard coding the keywords meta tag and values into each page.  I moved the keywords information to the _pages/home.md file as a yml frontmatter field as well as added logic to the _includes/head.html file so that in the future if other pages need keyword values on the page, they can simply be added to the frontmatter for each page.  If there is no "keywords" value on the page, then it will not display the "keywords" meta tag.

- [x] Additionally, tweaked the README file adding in the publications directory to the structure and added some additional comments to the top of each include file to provide additional information if they need to be included to other pages in the future.