### PR TITLE
Addition of yml validation and incorporation into CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ site/_site/
 coverage
 .ruby-version
 .sass-cache
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
-language: ruby
-rvm:
-  - 2.1
+language: node_js
+node_js:
+  - 4.2
+before_install:
+# execute commands before dependencies can be installed
+  - rvm install 2.1  
+  - npm install -g grunt-cli
+install:
+# install dependencies
+  - bundle install
+  - npm install
 script:
-  - bundle exec jekyll build
-  - bundle exec htmlproof ./_site --only-4xx --check-html --ignore-script-embeds --file-ignore "/mlab_observatory/"
+  - grunt test
 branches:
   only:
   - master

--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,7 @@ gem 'liquid'
 gem 'jekyll'
 gem 'jekyll-paginate'
 gem 'html-proofer'
+
+group :jekyll_plugins do
+	gem 'jekyll_frontmatter_tests', '0.0.6', :path => 'jekyll_frontmatter_tests-0.0.6'
+end

--- a/README.md
+++ b/README.md
@@ -8,9 +8,18 @@ Current Build Status is: [![Build Status](https://secure.travis-ci.org/m-lab/m-l
 
 **Please Note** This repository contains a submodule, so after cloning this repo, you will also need to run `git submodule init` and `git submodule update` to pull down the submodule files as well.
 
-1. Install dependencies `bundle install`
-2. Run Jekyll server to preview in development mode `jekyll serve`.
-3. View the generated site by going to [http://localhost:4000/](http://localhost:4000/)
+1. Install ruby dependencies `bundle install` (only needed upon initially cloning or when gemfile is updated)
+2. Install grunt `npm install -g grunt-cli` (only needed upon initially cloning or when package.json is updated)
+3. Install node dependencies which are used for linting/testing `npm install`
+4. Execute the grunt task from chart [below](#grunt-tasks) or simply run Jekyll server to preview in development mode `jekyll serve`.  To regenerate the site automatically use the watcher option `-w`.
+5. View the generated site by going to [http://localhost:4000/](http://localhost:4000/)
+
+### Grunt tasks
+| Task | Description |
+| ------------- |:------------- |
+| grunt | This is the default task that will validate all yml and then build the site |
+| grunt serve | This task is generally used for development and is equivalent to `jekyll serve` |
+| grunt test | This task is run during CI and should always be run before pull requests are made |
 
 ### HTML Compression
 

--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,11 @@ exclude:
   - README.md
   - Gemfile
   - Gemfile.lock
+  - deploy
+  - jekyll_frontmatter_tests-0.0.6
+  - node_modules
+  - gruntfile.js
+  - package.json
 
 # Gems
 gems: ['jekyll-paginate', 'jekyll-feed']

--- a/deploy/tests/schema/_category.yml
+++ b/deploy/tests/schema/_category.yml
@@ -1,0 +1,15 @@
+---
+layout: "String"
+title: "String"
+permalink: "String"
+archive-name: "String"
+archive-type: "String"
+breadcrumb: "String"
+config:
+  path: ['_pages/categories']
+  ignore:
+  - README.md
+  - ..
+  - .
+  - .DS_Store
+---

--- a/deploy/tests/schema/_date.yml
+++ b/deploy/tests/schema/_date.yml
@@ -1,0 +1,15 @@
+---
+layout: "String"
+title: "String"
+permalink: "String"
+archive-name: "String"
+archive-type: "String"
+breadcrumb: "String"
+config:
+  path: ['_pages/dates']
+  ignore:
+  - README.md
+  - ..
+  - .
+  - .DS_Store
+---

--- a/deploy/tests/schema/_page.yml
+++ b/deploy/tests/schema/_page.yml
@@ -1,0 +1,13 @@
+---
+layout: "String"
+title: "String"
+permalink: "String"
+config:
+  path: ['_pages']
+  ignore:
+  - README.md
+  - ..
+  - .
+  - .DS_Store
+  optional: ['breadcrumb', 'sub-nav', 'audience', 'heading', 'menu-item', 'page-title', 'accordion', 'grid-quick-links', 'grid-section']
+---

--- a/deploy/tests/schema/_post.yml
+++ b/deploy/tests/schema/_post.yml
@@ -1,0 +1,14 @@
+---
+layout: "String"
+title: "String"
+author: "String"
+breadcrumb: "String"
+config:
+  path: '_posts/blog'
+  ignore:
+  - README.md
+  - ..
+  - .
+  - .DS_Store
+  optional: ['categories']
+---

--- a/deploy/tests/schema/_tool.yml
+++ b/deploy/tests/schema/_tool.yml
@@ -1,0 +1,13 @@
+---
+layout: "String"
+title: "String"
+permalink: "String"
+breadcrumb: "String"
+config:
+  path: ['_pages/tools']
+  ignore:
+  - README.md
+  - ..
+  - .
+  - .DS_Store
+---

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,0 +1,68 @@
+'use strict';
+
+module.exports = function (grunt) {
+
+    // Show elapsed time after tasks run to visualize performance
+    require('time-grunt')(grunt);
+    // Load all Grunt tasks that are listed in package.json automagically
+    require('load-grunt-tasks')(grunt);
+
+    grunt.initConfig({
+        pkg: grunt.file.readJSON('package.json'),
+
+        // shell commands for use in Grunt tasks
+        shell: {
+            jekyllBuild: {
+                command: 'bundle exec jekyll build'
+            },
+            jekyllServe: {
+                command: 'jekyll serve'
+            },
+            jekyllTest: {
+                command: 'jekyll test'
+            },
+            htmlproofer: {
+                command: 'bundle exec htmlproof ./_site --only-4xx --check-html --ignore-script-embeds --file-ignore "/mlab_observatory/" --href-ignore "/getinvolved/"'
+            }
+        },
+
+        yaml_validator: {
+            custom: {
+              options: {
+                yaml: {
+                  onWarning: function (error, filepath) {
+                    console.log(filepath + ' has error: ' + error);
+                  }
+                }
+              },
+              src: ['_data/*.yml']
+            }
+        }
+
+    });
+
+    // Register the grunt serve task
+    grunt.registerTask('serve', [
+        'shell:jekyllServe'
+    ]);
+
+    // Register the grunt build task
+    grunt.registerTask('build', [
+        'shell:jekyllTest',
+        'yaml_validator:custom',
+        'shell:jekyllBuild'
+    ]);
+
+    // Register the grunt build task
+    grunt.registerTask('test', [
+        'shell:jekyllTest',
+        'yaml_validator:custom',
+        'shell:jekyllBuild',
+        'shell:htmlproofer'
+
+    ]);
+
+    // Register build as the default task fallback
+    grunt.registerTask('default', 'build');
+
+};

--- a/jekyll_frontmatter_tests-0.0.6/lib/jekyll_frontmatter_tests.rb
+++ b/jekyll_frontmatter_tests-0.0.6/lib/jekyll_frontmatter_tests.rb
@@ -1,0 +1,213 @@
+require 'yaml'
+class FrontmatterTests < Jekyll::Command
+  class << self
+    # Public: load the configuration file
+    #
+    # Assumes this is a standard jekyll site
+    def config
+      config = Jekyll.configuration
+      if config.key('frontmatter_tests').nil?
+        config['frontmatter_tests'] = {'path' => File.join("deploy", "tests", "schema")}
+      end
+      @config ||= config['frontmatter_tests']
+    end
+
+    # Public: Load a schema from file.
+    #
+    # file - a string containing a filename
+    #
+    # Used throughout to load a specific file. In the future the directories
+    # where these schema files are located could be loaded from _config.yml
+    #
+    # Returns a hash loaded from the YAML doc or exits 1 if no schema file
+    # exists.
+    def loadschema(file)
+      schema = File.join("deploy", "tests", "schema", file)
+    	if File.exists?(schema)
+        YAML.load_file(schema)
+      else
+        puts "No schema for #{file}"
+        exit 1
+      end
+    end
+
+    # Public: processes a collection against a schema
+    #
+    # schema - the hash-representation of a schema file
+    #
+    # Opens each file in the collection's expected directory and checks the
+    # file's frontmatter for the expected keys and the expected format of the
+    # values.
+    #
+    # Returns true or false depending on the success of the check.
+    def process(schema)
+    	dir = File.join(schema['config']['path'])
+    	passfail = Array.new
+    	Dir.open(dir).each do |f|
+        next if File.directory?(File.join(dir, f))
+    		file = File.open(File.join(dir, f))
+    		unless schema['config']['ignore'].include?(f)
+    			data = YAML.load_file(file)
+    			passfail.push check_keys(data, schema.keys, f)
+    			passfail.push check_types(data, schema)
+    		end
+    	end
+      passfail.keep_if { |p| p == false }
+    	if passfail.empty?
+    		return true
+    	else
+        puts "There were #{passfail.count} errors".red
+    		return false
+    	end
+    end
+
+    # Public: checks a hash for expected keys
+    #
+    # target - the hash under test
+    # keys - an array of keys the data is expected to have, usually loaded from
+    #        a schema file by loadschema()
+    # title - A string representing `data`'s name
+    def check_keys(target, keys, title)
+    	keys = keys - ['config']
+    	unless target.respond_to?('keys')
+    		puts "The file #{title} is missing all frontmatter.".red
+    		return false
+    	end
+    	diff = keys - target.keys
+      if diff.empty?
+    		return true
+    	else
+    		puts "\nThe file #{title} is missing the following keys:".red
+    		for k in diff
+    			puts "    * #{k}".red
+    		end
+    		return false
+    	end
+    end
+
+    # Public: tests all documents that are "posts"
+    #
+    # Loads a schema called _posts.yml and processes all post documents against
+    # it.
+    def test_posts
+      puts 'testing posts'.green
+      yepnope = Array.new.push process(loadschema('_posts.yml'))
+      puts 'Finished testing'.green
+      yepnope
+    end
+
+    # Public: Tests only specific collection documents
+    #
+    # collections - a comma separated string of collection names.
+    #
+    # `collections` is split into an array and each document is loaded and
+    # processed against its respective schema.
+    def test_collections(collections)
+      yepnope = Array.new
+      for c in collections
+        puts "Testing #{c}".green
+        yepnope.push process(loadschema("_#{c}.yml"))
+        puts "Finished testing #{c}".green
+      end
+      yepnope
+    end
+
+    # Public: Tests all collections described by a schema file at
+    # `deploy/tests/scema`
+    def test_everything
+      schema = Dir.open('deploy/tests/schema')
+      yepnope = Array.new
+      schema.each { |s|
+        if s.start_with?('_')
+          puts "Testing #{s}".green
+          yepnope.push process(loadschema(s))
+          puts "Finished testing #{s}".green
+        end
+      }
+      yepnope
+    end
+
+    # Public: Processes options passed throguh the command line, runs
+    # the appropriate tests.
+    #
+    # args - command line arguments (example: jekyll test [ARG])
+    # options - command line options (example: jekyll test -[option] [value])
+    #
+    # Depending on the flag passed (see `init_with_program`), runs the expected # test.
+    #
+    # Example: the following comamnd `jekyll test -p` will pass ``{'posts' =>
+    #          true}` as `options`. This will cause `test_frontmatter` to
+    #          compare all docs in _posts with the provided schema.
+    #
+    # The test runner pushes the result of each test into a `results` array and # exits `1` if any tests fail or `0` if all is well.
+    def test_frontmatter(args, options)
+      puts 'starting tests'
+      if options['posts']
+        results = test_posts
+      elsif options['collections']
+        collections = options['collections'].split(',')
+        results = test_collections(collections)
+      else
+        results = test_everything
+      end
+      unless results.find_index{ |r| r == false }
+        puts 'Tests finished!'
+        exit 0
+      else
+        puts "The test exited with errors, see above."
+        exit 1
+      end
+    end
+
+    # Internal: fired when `jekyll test` is run.
+    #
+    # When `jekyll test` runs, `test_frontmatter` is fired with options and args
+    # passed from the command line.
+    def init_with_program(prog)
+      prog.command(:test) do |c|
+        c.syntax "test [options]"
+        c.description 'Test your site for frontmatter.'
+
+        c.option 'posts', '-p', 'Target only posts'
+        c.option 'collections', '-c [COLLECTION]', 'Target a specific collection'
+        c.option 'all', '-a', 'Test all collections (Default)'
+
+        c.action do |args, options|
+          if options.empty?
+            options = {"all" => true}
+          end
+          test_frontmatter(args, options)
+        end
+      end
+    end
+    # Internal: eventually, validate that the *values* match expected types
+    #
+    # For example, if we expect the `date` key to be in yyyy-mm-dd format, validate
+    # that it's been entered in that format. If we expect authors to be an array,
+    # make sure we're getting an array.
+    def check_types(data, schema)
+    	unless data.respond_to?('keys')
+    		return false
+    	end
+    	for s in schema
+    		key  = s[0]
+    		if s[1].class == Hash
+    			type = s[1]['type']
+    		else
+    			type = s[1]
+    		end
+
+    		if type == "Array" and data[key].class == Array
+    			return true
+    		elsif type == "String" and data[key].class == String
+    			return true
+    		elsif type == "Date"
+    			return true
+    		else
+    			puts "    * Data is of the wrong type for key #{key}, expected #{type} but was #{data[key].class}\n\n"
+    			return false
+    		end
+    	end
+    end
+  end
+end

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "M-Lab",
+  "description": "Jekyll site that serves http://www.measurementlab.net/",
+  "version": "0.1.0",
+  "devDependencies": {
+    "grunt": "~0.4.5",
+    "grunt-contrib-watch": "~0.6.1",
+    "grunt-shell": "^1.1.2",
+    "load-grunt-tasks": "~0.6.0",
+    "time-grunt": "~0.4.0",
+    "grunt-yaml-validator": "~0.9.0"
+  }
+}


### PR DESCRIPTION
**NOTE** - This will probably conflict with https://github.com/m-lab/m-lab.github.io/pull/47, so I can rebase after https://github.com/m-lab/m-lab.github.io/pull/47 is accepted/merged.

This pull request implements additional validation on yml used throughout the site and integrates it with Travis CI.

- [x] Implemented 2 forms of yml validation:
    - The first yml validation tests yml frontmatter contained in posts and pages against a yml "schema".  It is using a modified version of the jekyll_frontmatter_tests gem.  I needed to tweak the gem in order for the validation to skip nested directories, i.e. - _pages/categories, _pages/dates, etc.  So, this will enforce things such as pages or posts that REQUIRE certain yml frontmatter fields, formatting/linting of frontmatter, as well as yml key types, i.e. - strings, array.
**Example:** - Let's say a future developer leaves out the ``archive-type`` yml frontmatter in a category page and then ran this yml validation test, they would see something like below:
<img width="475" alt="screen shot 2016-02-27 at 3 43 57 pm" src="https://cloud.githubusercontent.com/assets/2396774/13375298/8050bfaa-dd69-11e5-8ec3-b316886a61eb.png">

    - The second yml validation tests basic linting of all yml files within the _data directory.  Currently there is only 1 file there, but if others are added it may be advantageous to have yml linting on those files too.  It would be possible to have a schema defined for these yml files as well, however, I'd only recommend this when the yml file is containing data other than just content.
**Example:** - Let's say a future developer incorporates a new yml file in _data and there is incorrectly formatted yml, running the yml validation test will display an error like below:
<img width="824" alt="screen shot 2016-02-27 at 3 44 57 pm" src="https://cloud.githubusercontent.com/assets/2396774/13375308/be6ee1b8-dd69-11e5-8442-2f7ff788bcec.png">


- [x] In order to implement the yml validation within Travis CI, a grunt file was created with several tasks.  This should also aid in local development of the site too and can be expanded on if other tests/linting/tasks are desired in the future.  All of the grunt tasks created were also documented in the README.md file, but include:
    -  ``grunt serve`` task - intended for local development
    - ``grunt test`` task - intended to be run upon completion of development and in CI for tests to run
    - a default ``grunt`` task - intended to run the build and all tests, except htmlproofer since this one can take a little longer to execute all the external link checks.