### PR TITLE
Adds an S3 deploy block to the Travis-CI config file to push to our S3 bucket.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ deploy:
     secure: BlXQIyq/lHCHPGX5YUasTGWHkoL32lZHYG/n1yLBjniht2AKPWBnbQ+oWLJt2d28xZksXaDYQ02rh8lWted0SKhqYUN6dcmrXu8rVwcqpqgihUZsC1yqO4qGZ2qGkeQ2X0+HSKIBJ5VUKrMJiS3YK+N/W00/f9FatrSGvr8HBKSWpKpDiHq7z5kx/ab5Aae0hGyN1Ux6I7jTkYDI6oi9gQFJgv4oMKUt11SVMqnBNXoeOvDnIIkJqSf0hKuSZpeEDoX1FDlEaC/NR11ASlPj1ev+mxuNi1S1WTYFka7tB7piD9TQTv0PxjU+t4+TaH9jkd35eGUW1VeKPrdBtsK2TnCM6zYuM7/4U2i/7ZHf4bRVG8UkL+h32K25b24SQIyJddAzvrz8cM2/TLpqid+xdvay2Ax5T3acsxQhBq+vXVwohhl2q3fu9o6o6Bh8SGnn7XSK3JxE9Z3e8Uqg9JV3Pmgz8VyeYCwjuaV5lyabujQAn6sX8rw0RQ2A35bvQjAkNDiLUsmmOQBuRnnmS6fxeYDWf1D/h+6V0TWqPFQLTNBCjYt7WBDyTAU6i71c8ZDSay2CqVca0djxzXJHuqys5q4gRqXpLkuOiJUJMR8s5NhgQAI6bSCkgsJ/EcJqpSIwI72W+NgBb0I31KeREJXO5UlNmTa7RBFSX02KE23ut/E=
   bucket: www-measurementlab-net
   acl: ''
+  skip_cleanup: true
   on:
     repo: m-lab/m-lab.github.io
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,13 @@ branches:
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
+deploy:
+  provider: s3
+  access_key_id: AKIAIRWAFHZDDWJ37X5A
+  secret_access_key:
+    secure: BlXQIyq/lHCHPGX5YUasTGWHkoL32lZHYG/n1yLBjniht2AKPWBnbQ+oWLJt2d28xZksXaDYQ02rh8lWted0SKhqYUN6dcmrXu8rVwcqpqgihUZsC1yqO4qGZ2qGkeQ2X0+HSKIBJ5VUKrMJiS3YK+N/W00/f9FatrSGvr8HBKSWpKpDiHq7z5kx/ab5Aae0hGyN1Ux6I7jTkYDI6oi9gQFJgv4oMKUt11SVMqnBNXoeOvDnIIkJqSf0hKuSZpeEDoX1FDlEaC/NR11ASlPj1ev+mxuNi1S1WTYFka7tB7piD9TQTv0PxjU+t4+TaH9jkd35eGUW1VeKPrdBtsK2TnCM6zYuM7/4U2i/7ZHf4bRVG8UkL+h32K25b24SQIyJddAzvrz8cM2/TLpqid+xdvay2Ax5T3acsxQhBq+vXVwohhl2q3fu9o6o6Bh8SGnn7XSK3JxE9Z3e8Uqg9JV3Pmgz8VyeYCwjuaV5lyabujQAn6sX8rw0RQ2A35bvQjAkNDiLUsmmOQBuRnnmS6fxeYDWf1D/h+6V0TWqPFQLTNBCjYt7WBDyTAU6i71c8ZDSay2CqVca0djxzXJHuqys5q4gRqXpLkuOiJUJMR8s5NhgQAI6bSCkgsJ/EcJqpSIwI72W+NgBb0I31KeREJXO5UlNmTa7RBFSX02KE23ut/E=
+  bucket: www-measurementlab-net
+  acl: ''
+  on:
+    repo: m-lab/m-lab.github.io
+    branch: master

--- a/README.md
+++ b/README.md
@@ -45,3 +45,10 @@ This section highlights the coding standards to be used for this project to ensu
 - All liquid variables are following an underscore pattern so they can be easier to differentiate from yml frontmatter variables
 - All liquid tags, objects, and filtesr will have spaces in front of and following whatever is contained within braces
 
+### Travis CI integration
+
+This repository contains a _.travis.yml_ file which configures how it will interact with [Travis CI](https://travis-ci.org/) for continuous integration after new commits are pushed. Travis is configured to take the following actions after a push:
+
+- Build a static Jekyll site from the source.
+- Deploy the built site to Amazon S3. In order to [deploy to S3](https://docs.travis-ci.com/user/deployment/s3/), the secret key for the Amazon AWS [IAM account](https://aws.amazon.com/iam/) to be used must be encrypted in .travis.yml. The secret key is [encrypted](https://docs.travis-ci.com/user/encryption-keys/) using the public key for the repository in Travis CI. If the Amazon credentials change, then the keys in .travis.yml will need to be updated. The ```access_key_id``` can be entered in plain text, but the secret key should be encryped using the [travis CLI utility](https://github.com/travis-ci/travis.rb) like so:
+> ```$ travis encrypt access_key_id:<SECRET KEY> -r m-lab/m-lab.github.io```

--- a/README.md
+++ b/README.md
@@ -47,9 +47,11 @@ This section highlights the coding standards to be used for this project to ensu
 
 ### Travis CI integration
 
-This repository contains a _.travis.yml_ file which configures how it will interact with [Travis CI](https://travis-ci.org/) for continuous integration after new commits are pushed. Travis is configured to take the following actions after a push:
+Travis is configured (via .travis.yml) to take the following actions after a push:
 
 - Build a static Jekyll site from the source.
-- Deploy the built site to Amazon S3. In order to [deploy to S3](https://docs.travis-ci.com/user/deployment/s3/), the secret key for the Amazon AWS [IAM account](https://aws.amazon.com/iam/) to be used must be encrypted in .travis.yml. The secret key is [encrypted](https://docs.travis-ci.com/user/encryption-keys/) using the public key for the repository in Travis CI. If the Amazon credentials change, then the keys in .travis.yml will need to be updated. The ```access_key_id``` can be entered in plain text, but the secret key should be encryped using the [travis CLI utility](https://github.com/travis-ci/travis.rb) like so:
+- Deploy the built site to Amazon S3.
+
+In order to [deploy to S3](https://docs.travis-ci.com/user/deployment/s3/), the secret key for the Amazon AWS [IAM account](https://aws.amazon.com/iam/) to be used must be encrypted in .travis.yml. The secret key is [encrypted](https://docs.travis-ci.com/user/encryption-keys/) using the public key for the repository in Travis CI. If the Amazon credentials change, then the keys in .travis.yml will need to be updated. The ```access_key_id``` can be entered in plain text, but the secret key should be encryped using the [travis CLI utility](https://github.com/travis-ci/travis.rb) like so:
 
     ```$ travis encrypt secret_access_key:<SECRET KEY> -r m-lab/m-lab.github.io```

--- a/README.md
+++ b/README.md
@@ -51,4 +51,5 @@ This repository contains a _.travis.yml_ file which configures how it will inter
 
 - Build a static Jekyll site from the source.
 - Deploy the built site to Amazon S3. In order to [deploy to S3](https://docs.travis-ci.com/user/deployment/s3/), the secret key for the Amazon AWS [IAM account](https://aws.amazon.com/iam/) to be used must be encrypted in .travis.yml. The secret key is [encrypted](https://docs.travis-ci.com/user/encryption-keys/) using the public key for the repository in Travis CI. If the Amazon credentials change, then the keys in .travis.yml will need to be updated. The ```access_key_id``` can be entered in plain text, but the secret key should be encryped using the [travis CLI utility](https://github.com/travis-ci/travis.rb) like so:
-> ```$ travis encrypt secret_access_key:<SECRET KEY> -r m-lab/m-lab.github.io```
+
+    ```$ travis encrypt secret_access_key:<SECRET KEY> -r m-lab/m-lab.github.io```

--- a/README.md
+++ b/README.md
@@ -51,4 +51,4 @@ This repository contains a _.travis.yml_ file which configures how it will inter
 
 - Build a static Jekyll site from the source.
 - Deploy the built site to Amazon S3. In order to [deploy to S3](https://docs.travis-ci.com/user/deployment/s3/), the secret key for the Amazon AWS [IAM account](https://aws.amazon.com/iam/) to be used must be encrypted in .travis.yml. The secret key is [encrypted](https://docs.travis-ci.com/user/encryption-keys/) using the public key for the repository in Travis CI. If the Amazon credentials change, then the keys in .travis.yml will need to be updated. The ```access_key_id``` can be entered in plain text, but the secret key should be encryped using the [travis CLI utility](https://github.com/travis-ci/travis.rb) like so:
-> ```$ travis encrypt access_key_id:<SECRET KEY> -r m-lab/m-lab.github.io```
+> ```$ travis encrypt secret_access_key:<SECRET KEY> -r m-lab/m-lab.github.io```

--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ Travis is configured (via .travis.yml) to take the following actions after a pus
 
 In order to [deploy to S3](https://docs.travis-ci.com/user/deployment/s3/), the secret key for the Amazon AWS [IAM account](https://aws.amazon.com/iam/) to be used must be encrypted in .travis.yml. The secret key is [encrypted](https://docs.travis-ci.com/user/encryption-keys/) using the public key for the repository in Travis CI. If the Amazon credentials change, then the keys in .travis.yml will need to be updated. The ```access_key_id``` can be entered in plain text, but the secret key should be encryped using the [travis CLI utility](https://github.com/travis-ci/travis.rb) like so:
 
-    ```$ travis encrypt secret_access_key:<SECRET KEY> -r m-lab/m-lab.github.io```
+```$ travis encrypt secret_access_key:<SECRET KEY> -r m-lab/m-lab.github.io```


### PR DESCRIPTION
Whenever a commit is made to the master branch of this repo, we want Travis-CI to build the site and then automatically push it to our AWS S3 bucket, where it will ultimately be served up to the world via AWS CloudFront.