### PR TITLE
Setting markdown processor to kramdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,7 @@ excerpt_separator: <!--more-->
 permalink: "/blog/:title/"
 sass:
   sass_dir: _sass
+markdown: kramdown
 include: ['_pages']
 exclude:
   - .gitignore


### PR DESCRIPTION
This is the markdown processor that Github pages uses.