### PR TITLE
Adding partial data documentation

### DIFF
--- a/_data/header-footer-content.yml
+++ b/_data/header-footer-content.yml
@@ -25,6 +25,19 @@ header:
         - text: "Contact"
           url:  "/contact/"
     -
+      title: "data"
+      sub-nav:
+        - text: "Overview"
+          url:  "/data/"
+        - text: "Google Cloud Storage"
+          url:  "/data/gcs/"
+        - text: "BigQuery QuickStart"
+          url:  "/data/bq/quickstart/"
+        - text: "BigQuery Examples"
+          url:  "/data/bq/examples/"
+        - text: "BigQuery Schema"
+          url:  "/data/bq/schema/"
+    -
       title: "visualizations"
       sub-nav:
         - text: "Performance"

--- a/_pages/04-data.md
+++ b/_pages/04-data.md
@@ -1,0 +1,10 @@
+---
+layout: page
+permalink: /data/
+title: "Data"
+page-title: "Overview"
+menu-item: true
+breadcrumb: data
+---
+
+TODO(mtlynch): Fill this in.

--- a/_pages/bigquery_examples.md
+++ b/_pages/bigquery_examples.md
@@ -1,0 +1,168 @@
+---
+layout: page
+title: "BigQuery Examples"
+permalink: /data/bq/examples/
+breadcrumb: data
+---
+
+# Overview
+
+The examples below query the M-Lab data in various ways to demonstrate effective use of the M-Lab BigQuery dataset.
+
+# Basic counting — How many users?
+
+Let's start with something simple. How many distinct users (distinct IPs for simplicity) have ever run an **NDT** test?
+
+~~~sql
+SELECT
+  COUNT(DISTINCT web100_log_entry.connection_spec.remote_ip) AS num_clients
+FROM
+  plx.google:m_lab.ndt.all
+WHERE
+  web100_log_entry.connection_spec.remote_ip IS NOT NULL;
+~~~
+
+Result:
+
+| num_clients |
+|-------------|
+| 110814220   |
+
+# Computing statistics over time — How many users per day?
+
+By slightly modifying the previous query, it is possible to compute how the number of users changed over time.
+
+ * The multiplication by `POW(10, 6)` is due to the fact that `STRFTIME_UTC_USEC` expects a timestamp in microseconds, while `web100_log_entry.log_time` is in seconds. The [BigQuery Query Reference][13] describes the `STRFTIME_UTC_USEC` function.
+
+~~~sql
+SELECT
+  STRFTIME_UTC_USEC(web100_log_entry.log_time * INTEGER(POW(10, 6)),
+                    '%Y-%m-%d') AS day,
+  COUNT(DISTINCT web100_log_entry.connection_spec.remote_ip) AS num_clients
+FROM
+  plx.google:m_lab.ndt.all
+WHERE
+  web100_log_entry.connection_spec.remote_ip IS NOT NULL
+GROUP BY
+  day
+ORDER BY
+  day ASC;
+~~~
+
+**Result**
+
+|    day      | num_clients |
+|-------------|-------------|
+| 2009-02-18  |           1 |
+| 2009-02-21  |          31 |
+| 2009-02-22  |         115 |
+| 2009-02-23  |          73 |
+| 2009-02-24  |         105 |
+| ...         |         ... |
+| 2015-12-27  |       52995 |
+| 2015-12-28  |       50751 |
+
+# Dealing with IP addresses — How many users from distinct subnets?
+
+BigQuery supports various functions to parse IP addresses in different formats. You can use such functions to aggregate the number of users per subnet and compute how many subnets have ever initiated a test.
+
+* The following query aggregates the client IP addresses into /24s and counts the number of unique /24s that have ever initiated at least one NDT test.
+* `PARSE_IP(remote_ip) & INTEGER(POW(2, 32) - POW(2, 32 - 24)))` computes a bit-wise AND between `web100_log_entry.connection_spec.remote_ip` and 255.255.255.0. The [BigQuery Query Reference](https://cloud.google.com/bigquery/query-reference#ipfunctions) describes the `PARSE_IP` and `FORMAT_IP` functions.
+
+~~~sql
+SELECT
+  COUNT(DISTINCT FORMAT_IP(PARSE_IP(web100_log_entry.connection_spec.remote_ip)
+        & INTEGER(POW(2, 32) - POW(2, 32 - 24)))) AS num_subnets
+FROM
+  plx.google:m_lab.ndt.all
+~~~
+
+**Result**
+
+| num_subnets |
+|-------------|
+| 4548859     |
+
+# Comparing NDT and NPAD tests — How many users have run both NDT and NPAD tests?
+
+* The following query computes the number of distinct IP addresses that have run tests using both NDT and NPAD.
+* The inner query is an inner join between the NDT and NPAD tables containing the rows where the remote IP field in both tables match.
+* The outer query simply counts the number of results from the inner query (i.e. the number of rows with matching remote IP addresses).
+
+~~~sql
+SELECT
+  COUNT(*) AS num_ip_addresses
+FROM
+  (
+  SELECT
+    npad.web100_log_entry.connection_spec.remote_ip,
+  FROM
+    plx.google:m_lab.npad.all AS npad
+  JOIN
+    plx.google:m_lab.npad.all AS ndt
+  ON
+    (npad.web100_log_entry.connection_spec.remote_ip =
+     ndt.web100_log_entry.connection_spec.remote_ip)
+  GROUP BY
+    npad.web100_log_entry.connection_spec.remote_ip
+  )
+~~~
+
+**Result**
+
+|num_ip_addresses|
+|----------------|
+|           74535|
+
+# Computing distributions of tests across users — How many users have run a certain number of tests?
+
+Now let's try something a bit more complex.
+
+Some IP addresses may have many initiated tests, while others only have a few tests. To assess the representation of each IP address, we can classify the IP addresses based on the number of tests they have initiated.
+
+* The following query computes the number of NDT tests initiated by each client IP address, groups the IP addresses by the number of tests run, and returns the number of IP addresses in each group.
+* The inner query calculates the number of NDT tests that each client performed in December 2015. The query uses the `GROUP BY` clause to collapse all the rows with the same `remote_ip`. The [BigQuery Query Reference][15] describes the `GROUP BY` command.
+* The outer query transforms the results of the inner query by bucketing each client by the number of tests it performed, then calculating the number of clients in each bucket.
+
+~~~sql
+SELECT
+  num_tests,
+  COUNT(*) AS num_clients
+FROM
+  (
+    SELECT
+      COUNT(*) num_tests,
+      web100_log_entry.connection_spec.remote_ip AS remote_ip
+    FROM
+      plx.google:m_lab.ndt.all
+    WHERE
+      web100_log_entry.log_time >= PARSE_UTC_USEC('2015-12-01 00:00:00') / POW(10, 6)
+      AND web100_log_entry.log_time < PARSE_UTC_USEC('2016-01-01 00:00:00') / POW(10, 6)
+    GROUP BY
+      remote_ip
+  )
+GROUP BY
+  num_tests
+ORDER BY
+  num_tests ASC;
+~~~
+
+**Result**
+
+|num_tests|num_clients|
+|---------|-----------|
+|1        |267912     |
+|2        |453058     |
+|3        |94160      |
+|4        |113948     |
+|...      |...        |
+|5557     |1          |
+|5613     |1          |
+|26717    |1          |
+
+[3]: http://www.measurementlab.net/tools/ndt
+[4]: http://www.measurementlab.net/tools/npad
+[5]: http://www.measurementlab.net/tools/sidestream
+[6]: http://www.measurementlab.net/tools/paris-traceroute
+[13]: https://cloud.google.com/bigquery/query-reference#datetimefunctions
+[15]: https://cloud.google.com/bigquery/docs/query-reference#groupby

--- a/_pages/bigquery_quickstart.md
+++ b/_pages/bigquery_quickstart.md
@@ -1,0 +1,9 @@
+---
+layout: page
+title: "BigQuery QuickStart"
+permalink: /data/bq/quickstart/
+breadcrumb: data
+---
+
+TODO(mtlynch): Fill in
+

--- a/_pages/bigquery_schema.md
+++ b/_pages/bigquery_schema.md
@@ -1,0 +1,9 @@
+---
+layout: page
+title: "BigQuery Schema"
+permalink: /data/bq/schema/
+breadcrumb: data
+---
+
+TODO(mtlynch): Fill in
+

--- a/_pages/gcs.md
+++ b/_pages/gcs.md
@@ -1,0 +1,114 @@
+---
+layout: page
+title: Google Cloud Storage
+permalink: /data/gcs/
+breadcrumb: data
+---
+
+# Overview
+M-Lab publishes all data it collected in raw form as archives on Google Cloud Storage (GCS) at the following location:
+
+* [https://console.developers.google.com/storage/browser/m-lab/](https://console.developers.google.com/storage/browser/m-lab/)
+
+# File Layout
+
+All M-Lab files are packaged up in compressed tarballs. They are placed in folders and named according to the following schema:
+
+`[tool]/[YYYY]/[MM]/[DD]/[YYYYMMDD]T[HHMMSS]-[server]-[tool]-[file index].tgz`
+
+ * `tool`: The measurement tool that that generated the data.
+ * `YYYYMMDDTHHMMSS`: Start of the time window in which the data was collected.
+ * `server`: M-Lab server that collected the data.
+ * `file index`: Index of the file.
+
+This means that each tarball contains all the data collected during a single day, by a single tool running on a single M-Lab server.
+
+If the data collected during one day by one tool on one server are more than 1GB (uncompressed), the files are split into multiple tarballs of up to 1 GB in size.
+
+For example, the tarball `20090218T000000Z-mlab1-lga01-ndt-0000.tgz` contains the first 1 GB of data collected by all the NDT tests that were served by the M-Lab server mlab1-lga01 on Feb 18, 2009.
+
+# Project Data
+
+Direct links to each M-Lab project's raw data are available below:
+
+* [Glasnost](https://console.developers.google.com/storage/browser/m-lab/glasnost/)
+  * Glasnost detects prioritization or censorship of network traffic.
+  * More information is available at [MPI SWS](http://broadband.mpi-sws.org/transparency/bttest-mlab.php) and [Github](https://github.com/marcelscode/glasnost).
+* [NDT](https://console.developers.google.com/storage/browser/m-lab/ndt/)
+  * Network Diagnostic Tool (NDT) measures characteristics of a TCP connection under heavy load.
+  * More information is available at [Internet2](http://software.internet2.edu/ndt/) and [Github](https://github.com/ndt-project/ndt).
+* [Neubot](https://console.developers.google.com/storage/browser/m-lab/neubot/)
+  * Neubot measures the Internet in order to gather data useful to study broadband performance, network neutrality, and Internet censorship.
+  * More information is available at [Nexa Center](https://neubot.nexacenter.org/) and [Github](https://github.com/neubot).
+* [NPAD](https://console.developers.google.com/storage/browser/m-lab/npad/)
+  * Network Path and Application Diagnosis (NPAD) diagnoses issues in a network path that can degrade network performance.
+  * More information is available at [UCAR](http://www.ucar.edu/npad/) and [Github](https://github.com/npad/npad).
+* [OONI](https://console.developers.google.com/storage/browser/m-lab/ooni/)
+  * OONI measures censorship, surveillance and traffic manipulation on the Internet.
+  * More information is available at [OONI](https://ooni.torproject.org/)
+* [Paris Traceroute](https://console.developers.google.com/storage/browser/m-lab/paris-traceroute/)
+  * Paris Traceroute maps network topology between two points on the Internet.
+  * More information is available at [Paris Traceroute](http://www.paris-traceroute.net/).
+* [pathload2](https://console.developers.google.com/storage/browser/m-lab/pathload2/) (*deprecated*)
+  * *M-Lab no longer supports this tool, but its archived data is available on GCS. For similar measurements with a current and supported tool, see NDT.*
+  * Pathload2 measures the available bandwidth of an Internet connection.
+  * More information is available at [https://code.google.com/p/pathload2-gatech/](https://code.google.com/p/pathload2-gatech/).
+* [Shaperprobe](https://console.developers.google.com/storage/browser/m-lab/shaperprobe/) (*deprecated*)
+  * *M-Lab no longer supports this tool, but its archived data is available on GCS.*
+  * Shaperprobe detects prioritization of network traffic.
+  * More information is available at [ShaperProbe](http://netinfer.net/diffprobe/shaperprobe.html)
+* [SideStream](https://console.developers.google.com/storage/browser/m-lab/sidestream/)
+  * SideStream collects TCP state information about completed TCP connections on a system.
+  * More information is available on [Github](https://github.com/npad/sidestream).
+* [mlab-collectd](https://console.developers.google.com/storage/browser/m-lab/utilization/)
+  * mlab-collectd is a monitoring tool for M-Lab slices that collects resource utilization information about all M-Lab servers.
+  * More information is available on [Github](https://github.com/m-lab/collectd-mlab).
+
+# Accessing Data Programmatically
+
+## Accessing Data with `gsutil`
+
+The easiest way to access M-Lab data on GCS programmatically is by using the [`gsutil`](https://cloud.google.com/storage/docs/gsutil) command line utility.
+
+~~~ shell
+# List the contents of the M-Lab NDT data in GCS.
+$ gsutil ls -l gsutil ls -l gs://m-lab/
+
+# Copy a file from GCS locally.
+$ gsutil cp gs://m-lab/ndt/2009/02/18/20090218T000000Z-mlab1-lga01-ndt-0000.tgz .
+~~~
+
+## Accessing Data with Common HTTP Tools
+
+The URLs shown in [M-Lab's GCS web interface](https://console.developers.google.com/storage/browser/m-lab/) require the user to be logged in, which can present challenges when attempting to access the data with common HTTP utilities like `curl` or `wget`.
+
+You can access M-Lab files programmatically by replacing:
+
+`storage.cloud.google.com/m/cloudstorage/b`
+
+with
+
+`storage.googleapis.com`
+
+in any GCS URL.
+
+For example, if the URL of a raw NDT archive on the GCS Web application is:
+
+[https://storage.cloud.google.com/m/cloudstorage/b/m-lab/o/ndt/2015/12/28/20151228T000000Z-mlab1-lga04-ndt-0001.tgz](https://storage.cloud.google.com/m/cloudstorage/b/m-lab/o/ndt/2015/12/28/20151228T000000Z-mlab1-lga04-ndt-0001.tgz)
+
+You can access it without authentication via this URL:
+
+[https://storage.googleapis.com/m-lab/ndt/2015/12/28/20151228T000000Z-mlab1-lga04-ndt-0001.tgz](https://storage.googleapis.com/m-lab/ndt/2015/12/28/20151228T000000Z-mlab1-lga04-ndt-0001.tgz)
+
+## GCS File Index
+
+A list of all M-Lab files in GCS is available at:
+
+[https://storage.googleapis.com/m-lab/list/all_mlab_tarfiles.txt.gz](https://storage.googleapis.com/m-lab/list/all_mlab_tarfiles.txt.gz)
+
+This file provides `gs://` URLs to M-Lab data. To convert these URLs to `https://` URLs (compatible with common HTTP tools) you can convert the file using the following bash script:
+
+~~~shell
+$ curl https://storage.googleapis.com/m-lab/list/all_mlab_tarfiles.txt.gz | gunzip | \
+while read; do echo ${REPLY/gs:\/\//https://storage.googleapis.com/}; done
+~~~

--- a/_pages/infrastructure.md
+++ b/_pages/infrastructure.md
@@ -2,7 +2,6 @@
 layout: page
 permalink: /infrastructure/
 title: "Infrastructure"
-menu-item: true
 ---
 
 # M-Lab Platform


### PR DESCRIPTION
This adds documentation for GCS and BigQuery examples. The data overview,
BigQuery QuickStart, and BigQuery Schema pages are currently stubbed out. Because this is a partial change, this is being checked into a feature branch rather than master.

Note that this content has already been read and approved (see https://github.com/m-lab/m-lab.github.io/pull/5), but we need to re-integrate it because we reset the repo to zero when we did the initial Jekyll port.

The only changes since then are:
* Adds header metadata for creating menus/breadcrumbs
* Adds navigation metadata for the menu
* Changes triple-backticks to triple-tildes for code blocks (this is what [kramdown](http://kramdown.gettalong.org/syntax.html#code-blocks) uses)

A preview of these changes is available at: http://104.196.45.75:4000/data/

A few notes on the rendering:
* The CSS for code snippets is really bad and basically strips all formatting to make it look like normal text. We'll need to fix this before merging to master.
* The CSS for lists is also kind of weird and flattens everything out

Compare the rendering to the prototype site rendering of almost the exact same content: http://mtlynch.github.io/mlab-web/gcs/