### PR TITLE
Bug - Broken Travis Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 rvm:
-  - 2.1
+  - 2.2.3
 script:
   - bundle exec jekyll build
-  - bundle exec htmlproof ./_site --only-4xx --check-html --ignore-script-embeds --file-ignore "/mlab_observatory/"
+  - bundle exec htmlproofer ./_site --only-4xx --check-html --file-ignore "/mlab_observatory/"
 branches:
   only:
   - master

--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,4 @@ gem 'github-pages', versions['github-pages']
 gem 'liquid'
 gem 'jekyll'
 gem 'jekyll-paginate'
-gem 'html-proofer'
+gem 'html-proofer', '3.0.2'


### PR DESCRIPTION
I see that htmlproofer gem has been updated and therefore was causing some issues with the checks on travis builds.

In order to fix:
- updated some commands for the htmlproofer to work, using ``htmlproofer`` instead of ``htmlproof`` as well as removed the ``--ignore-script-embeds`` option now as it is deprecated.  By default script embeds are ignored unless specifically specified with the new htmlproofer option
- also updated rvm version to ensure latest environment and gems are used.