### PR TITLE
Removing branch restrictions from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ before_script:
 script:
   - bundle exec jekyll build
   - bundle exec htmlproofer ./_site --only-4xx --check-html --file-ignore "/mlab_observatory/"
-branches:
-  only:
-  - master
-  - gh-pages
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer


### PR DESCRIPTION
I noticed that Travis builds weren't happening on PRs to this branch and found that the .travis.yml excluded everything except `master` and `gh-pages`. I don't think that's intended behavior, so I'm removing those restrictions.