### PR TITLE
Adding Anchors for Data Pages

### DIFF
--- a/_pages/bigquery_examples.md
+++ b/_pages/bigquery_examples.md
@@ -3,12 +3,24 @@ layout: page
 title: "BigQuery Examples"
 permalink: /data/bq/examples/
 breadcrumb: data
+accordion-quick-links: true
+quick-links-section:
+  - column:
+    - group-heading: "Overview"
+    - group-heading: "Basic counting"
+    - group-heading: "Computing statistics over time"
+  - column:
+    - group-heading: "Dealing with IP addresses"
+    - group-heading: "Comparing NDT and NPAD tests"
+    - group-heading: "Computing distributions of tests across users"
 ---
 
+{:.overview}
 # Overview
 
 The examples below query the M-Lab data in various ways to demonstrate effective use of the M-Lab BigQuery dataset.
 
+{:.basic-counting}
 # Basic counting — How many users?
 
 Let's start with something simple. How many distinct users (distinct IPs for simplicity) have ever run an **NDT** test?
@@ -28,6 +40,7 @@ Result:
 |-------------|
 | 110814220   |
 
+{:.computing-statistics-over-time}
 # Computing statistics over time — How many users per day?
 
 By slightly modifying the previous query, it is possible to compute how the number of users changed over time.
@@ -62,6 +75,7 @@ ORDER BY
 | 2015-12-27  |       52995 |
 | 2015-12-28  |       50751 |
 
+{:.dealing-with-ip-addresses}
 # Dealing with IP addresses — How many users from distinct subnets?
 
 BigQuery supports various functions to parse IP addresses in different formats. You can use such functions to aggregate the number of users per subnet and compute how many subnets have ever initiated a test.
@@ -83,6 +97,7 @@ FROM
 |-------------|
 | 4548859     |
 
+{:.comparing-ndt-and-npad-tests}
 # Comparing NDT and NPAD tests — How many users have run both NDT and NPAD tests?
 
 * The following query computes the number of distinct IP addresses that have run tests using both NDT and NPAD.
@@ -114,6 +129,7 @@ FROM
 |----------------|
 |           74535|
 
+{:.computing-distributions-of-tests-across-users}
 # Computing distributions of tests across users — How many users have run a certain number of tests?
 
 Now let's try something a bit more complex.

--- a/_pages/gcs.md
+++ b/_pages/gcs.md
@@ -3,13 +3,23 @@ layout: page
 title: Google Cloud Storage
 permalink: /data/gcs/
 breadcrumb: data
+accordion-quick-links: true
+quick-links-section:
+  - column:
+    - group-heading: "Overview"
+    - group-heading: "File Layout"
+    - group-heading: "Project Data"
+    - group-heading: "Accessing Data Programmatically"
 ---
 
+{:.overview}
 # Overview
+
 M-Lab publishes all data it collected in raw form as archives on Google Cloud Storage (GCS) at the following location:
 
 * [https://console.developers.google.com/storage/browser/m-lab/](https://console.developers.google.com/storage/browser/m-lab/)
 
+{:.file-layout}
 # File Layout
 
 All M-Lab files are packaged up in compressed tarballs. They are placed in folders and named according to the following schema:
@@ -27,6 +37,7 @@ If the data collected during one day by one tool on one server are more than 1GB
 
 For example, the tarball `20090218T000000Z-mlab1-lga01-ndt-0000.tgz` contains the first 1 GB of data collected by all the NDT tests that were served by the M-Lab server mlab1-lga01 on Feb 18, 2009.
 
+{:.project-data}
 # Project Data
 
 Direct links to each M-Lab project's raw data are available below:
@@ -64,6 +75,7 @@ Direct links to each M-Lab project's raw data are available below:
   * mlab-collectd is a monitoring tool for M-Lab slices that collects resource utilization information about all M-Lab servers.
   * More information is available on [Github](https://github.com/m-lab/collectd-mlab).
 
+{:.accessing-data-programmatically}
 # Accessing Data Programmatically
 
 ## Accessing Data with `gsutil`


### PR DESCRIPTION
This PR adds quick link anchors at the top of 2 data pages per [issue 77](https://github.com/m-lab/m-lab.github.io/issues/77).

I wasn't sure if anchors were desired on any of the other pages?  I went with the logic that any of these pages that had a couple H1 headers that is what we have been putting quick link anchors on, so continuing with that theme.  If we want quick link anchors on the /data/bq/quickstart/ page, should we consider changing some of the main section headers to H1s or do we want to change the use of these?  It seems like it would give a more consistent experience for the end user to expect H1s for these anchors?  I'm open to what you all think is best though.

That aside, I was able to add anchors for the /data/gcs/ and /data/bq/examples/ pages.  Those changes can be seen on my fork [here](http://shredtechular.github.io/m-lab.github.io/data/gcs/) and [here](http://shredtechular.github.io/m-lab.github.io/data/bq/examples/), respectively.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/83)
<!-- Reviewable:end -->
