### PR TITLE
Bug - Data Table Styling

### DIFF
--- a/_posts/blog/2015-04-24-data_duplication_writeup.md
+++ b/_posts/blog/2015-04-24-data_duplication_writeup.md
@@ -26,7 +26,7 @@ This issue was introduced into the dataset sometime in May 2014. We fixed the ro
 
 The table below details the effect of the duplication bug on each of the BigQuery tables. Note that the table is organized not by time of query, but according to the time the M-Lab test occurred, as that is how M-Lab data is partitioned into tables in BigQuery.
 
-{:.big-query}
+{:#bigquery-schema-fields}
 |---
 | Month / BigQuery Table | Impact
 |:-|:-

--- a/_posts/blog/2015-04-24-data_duplication_writeup.md
+++ b/_posts/blog/2015-04-24-data_duplication_writeup.md
@@ -26,6 +26,7 @@ This issue was introduced into the dataset sometime in May 2014. We fixed the ro
 
 The table below details the effect of the duplication bug on each of the BigQuery tables. Note that the table is organized not by time of query, but according to the time the M-Lab test occurred, as that is how M-Lab data is partitioned into tables in BigQuery.
 
+{:.big-query}
 |---
 | Month / BigQuery Table | Impact
 |:-|:-

--- a/_sass/base/_base.scss
+++ b/_sass/base/_base.scss
@@ -10,11 +10,14 @@ ul {
 table {
   border-collapse: collapse;
   border-spacing: 0;
+  margin: 0px 0px 30px 0px;
 }
 
 caption,th,td {
   font-weight: normal;
   vertical-align: middle;
+  word-wrap: break-word;
+  max-width: 460px;
 }
 
 tr {
@@ -25,7 +28,6 @@ th {
   border: 1px solid black; 
   padding: 5px; 
   font-weight: bold; 
-  min-width: 200px;
 }
 
 td {

--- a/_sass/components/_tables.scss
+++ b/_sass/components/_tables.scss
@@ -1,0 +1,7 @@
+// Table component
+
+
+// Customized bigquery table
+table#bigquery-schema-fields {
+  @include tables(200px);
+}

--- a/_sass/helpers/_mixins.scss
+++ b/_sass/helpers/_mixins.scss
@@ -9,3 +9,9 @@
     line-height: $line-height;
   }
 }
+
+@mixin tables($min-width) {
+  th {
+    min-width: $min-width;
+  }
+}

--- a/_sass/pages/_blog.scss
+++ b/_sass/pages/_blog.scss
@@ -1,7 +1,0 @@
-// Unique elements for blog pages
-
-.blog-page {
-  table.big-query {
-    @include tables(200px);
-  }
-}

--- a/_sass/pages/_blog.scss
+++ b/_sass/pages/_blog.scss
@@ -1,0 +1,7 @@
+// Unique elements for blog pages
+
+.blog-page {
+  table.big-query {
+    @include tables(200px);
+  }
+}

--- a/css/base.scss
+++ b/css/base.scss
@@ -15,9 +15,7 @@
 @import 'components/accordions';
 @import 'components/quick-links';
 @import 'components/grids';
-
-// Include unique page elements
-@import 'pages/blog';
+@import 'components/tables';
 
 html,body,div,span,applet,object,iframe,h1,.carousel-caption p,.error-msg .error-text,h2,h3,h4,h5,h6,p,blockquote,pre,a,abbr,acronym,address,big,cite,code,del,dfn,em,img,ins,kbd,q,s,samp,small,strike,strong,sub,sup,tt,var,b,u,i,center,dl,dt,dd,ol,ul,li,fieldset,form,label,legend,caption,article,aside,canvas,details,embed,figure,figcaption,footer,header,hgroup,menu,nav,output,ruby,section,summary,time,mark,audio,video {
     margin: 0;

--- a/css/base.scss
+++ b/css/base.scss
@@ -16,6 +16,9 @@
 @import 'components/quick-links';
 @import 'components/grids';
 
+// Include unique page elements
+@import 'pages/blog';
+
 html,body,div,span,applet,object,iframe,h1,.carousel-caption p,.error-msg .error-text,h2,h3,h4,h5,h6,p,blockquote,pre,a,abbr,acronym,address,big,cite,code,del,dfn,em,img,ins,kbd,q,s,samp,small,strike,strong,sub,sup,tt,var,b,u,i,center,dl,dt,dd,ol,ul,li,fieldset,form,label,legend,caption,article,aside,canvas,details,embed,figure,figcaption,footer,header,hgroup,menu,nav,output,ruby,section,summary,time,mark,audio,video {
     margin: 0;
     padding: 0;


### PR DESCRIPTION
This PR is for some tables styling fixes that @mtlynch identified in https://github.com/m-lab/m-lab.github.io/issues/85.  You can see the fixes in action on my fork [here](http://shredtechular.github.io/m-lab.github.io/data/bq/schema/).

I think the fixes that can be applied to fix the styling on the data pages should both be more global fixes, however, there is a table in a blog page that is requiring the min-width attribute to be applied to one of its headers to ensure the formatting stays nice on that page too.  That's why I added the ``big-query`` class to that table in the blog post.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/91)
<!-- Reviewable:end -->
