### PR TITLE
Minor polish fixes to data pages

### DIFF
--- a/_linter/markdown-linter-style.rb
+++ b/_linter/markdown-linter-style.rb
@@ -40,3 +40,6 @@ exclude_rule 'MD032'
 
 ## MD026 - Emphasis used instead of a header
 exclude_rule 'MD036'
+
+## MD038 Spaces inside code span elements
+exclude_rule 'MD038'

--- a/_pages/04-data.md
+++ b/_pages/04-data.md
@@ -7,17 +7,17 @@ menu-item: true
 breadcrumb: data
 ---
 
-# About M-Lab's Data
+# Overview
 
 M-Lab publishes its data in two different forms:
 
--  Google Cloud Storage (raw files)
-   -   M-Lab publishes raw output from its measurement tools on Google Cloud Storage as file archives.
-   -   See the [M-Lab Google Cloud Storage documentation](/data/gcs) for more information.
+* Google Cloud Storage (raw files)
+  * M-Lab publishes raw output from its measurement tools on Google Cloud Storage as file archives.
+  * See the [M-Lab Google Cloud Storage documentation](/data/gcs) for more information.
 
--  Google BigQuery (SQL queryable)
-   - M-Lab parses data for a subset of its tools and publishes the data on BigQuery, so that users can run SQL queries over the data.
-   - See the [M-Lab BigQuery QuickStart](/data/bq/quickstart) for more information.
+* Google BigQuery (SQL queryable)
+  * M-Lab parses data for a subset of its tools and publishes the data on BigQuery, so that users can run SQL queries over the data.
+  * See the [M-Lab BigQuery QuickStart](/data/bq/quickstart) for more information.
 
 There is typically at least a 24-hour delay between data collection and data publication.
 
@@ -27,8 +27,8 @@ All data collected by M-Lab tests are available to the public without restrictio
 
 Please cite M-Lab datasets as follows:
 
-- The M-Lab _test name_ Dataset, _date range used_. _M-Lab test URL_
+* The M-Lab _test name_ Dataset, _date range used_. _M-Lab test URL_
 
 For example:
 
-- The M-Lab NDT Dataset 2009-02-11 - 2015-12-21. [https://measurementlab.net/tools/ndt](https://measurementlab.net/tools/ndt)
+* The M-Lab NDT Dataset 2009-02-11 - 2015-12-21. [https://measurementlab.net/tools/ndt](https://measurementlab.net/tools/ndt)

--- a/_pages/bigquery_examples.md
+++ b/_pages/bigquery_examples.md
@@ -5,11 +5,11 @@ permalink: /data/bq/examples/
 breadcrumb: data
 ---
 
-# Overview
+# BigQuery Examples
 
 The examples below query the M-Lab data in various ways to demonstrate effective use of the M-Lab BigQuery dataset.
 
-# Basic counting — How many users?
+## Basic counting — How many users?
 
 Let's start with something simple. How many distinct users (distinct IPs for simplicity) have ever run an **NDT** test?
 
@@ -22,17 +22,17 @@ WHERE
   web100_log_entry.connection_spec.remote_ip IS NOT NULL;
 ~~~
 
-Result:
+**Result**
 
 | num_clients |
 |-------------|
 | 110814220   |
 
-# Computing statistics over time — How many users per day?
+## Computing statistics over time — How many users per day?
 
 By slightly modifying the previous query, it is possible to compute how the number of users changed over time.
 
- * The multiplication by `POW(10, 6)` is due to the fact that `STRFTIME_UTC_USEC` expects a timestamp in microseconds, while `web100_log_entry.log_time` is in seconds. The [BigQuery Query Reference][13] describes the `STRFTIME_UTC_USEC` function.
+* The multiplication by `POW(10, 6)` is due to the fact that `STRFTIME_UTC_USEC` expects a timestamp in microseconds, while `web100_log_entry.log_time` is in seconds. The [BigQuery Query Reference][13] describes the `STRFTIME_UTC_USEC` function.
 
 ~~~sql
 SELECT
@@ -62,7 +62,7 @@ ORDER BY
 | 2015-12-27  |       52995 |
 | 2015-12-28  |       50751 |
 
-# Dealing with IP addresses — How many users from distinct subnets?
+## Dealing with IP addresses — How many users from distinct subnets?
 
 BigQuery supports various functions to parse IP addresses in different formats. You can use such functions to aggregate the number of users per subnet and compute how many subnets have ever initiated a test.
 
@@ -83,7 +83,7 @@ FROM
 |-------------|
 | 4548859     |
 
-# Comparing NDT and NPAD tests — How many users have run both NDT and NPAD tests?
+## Comparing NDT and NPAD tests — How many users have run both NDT and NPAD tests?
 
 * The following query computes the number of distinct IP addresses that have run tests using both NDT and NPAD.
 * The inner query is an inner join between the NDT and NPAD tables containing the rows where the remote IP field in both tables match.
@@ -114,14 +114,14 @@ FROM
 |----------------|
 |           74535|
 
-# Computing distributions of tests across users — How many users have run a certain number of tests?
+## Computing distributions of tests across users — How many users have run a certain number of tests?
 
 Now let's try something a bit more complex.
 
 Some IP addresses may have many initiated tests, while others only have a few tests. To assess the representation of each IP address, we can classify the IP addresses based on the number of tests they have initiated.
 
 * The following query computes the number of NDT tests initiated by each client IP address, groups the IP addresses by the number of tests run, and returns the number of IP addresses in each group.
-* The inner query calculates the number of NDT tests that each client performed in December 2015. The query uses the `GROUP BY` clause to collapse all the rows with the same `remote_ip`. The [BigQuery Query Reference][15] describes the `GROUP BY` command.
+* The inner query calculates the number of NDT tests that each client performed. The query uses the `GROUP BY` clause to collapse all the rows with the same `remote_ip`. The [BigQuery Query Reference][15] describes the `GROUP BY` command.
 * The outer query transforms the results of the inner query by bucketing each client by the number of tests it performed, then calculating the number of clients in each bucket.
 
 ~~~sql

--- a/_pages/bigquery_quickstart.md
+++ b/_pages/bigquery_quickstart.md
@@ -5,17 +5,19 @@ permalink: /data/bq/quickstart/
 breadcrumb: data
 ---
 
-## BigQuery QuickStart - Using M-Lab Data
+# BigQuery QuickStart
+
+## Configuring Access to M-Lab Data
 
 To search M-Lab's data using BigQuery, follow these quick steps to get started:
 
-### Configure Google Cloud Platform Project
+### 1. Configure Google Cloud Platform Project
 
 Create a project and enable billing in [Google Cloud Platform Console](https://console.developers.google.com/) (or use an existing project with billing enabled)
 
 You will **not** be charged for queries against tables in the M-Lab dataset. M-Lab is committed to open data and offering our data free of charge is part of that commitment.
 
-### Configure M-Lab Table Access
+### 2. Configure M-Lab Table Access
 
 Join the [M-Lab Discuss group](https://groups.google.com/a/measurementlab.net/forum/#!forum/discuss) with the same account you used to create your Google Cloud Platform project. Joining this group whitelists your account so that you can make queries against M-Lab's BigQuery tables.
 
@@ -44,18 +46,17 @@ SELECT
     day ASC;
 ~~~
 
-
 ## BigQuery tools in the Google Cloud SDK
 
 You may also run queries at the command line using BigQuery tools in the Google Cloud SDK.
 
-Download and Install [Google’s Cloud SDK](https://cloud.google.com/sdk/) using the Installation and Quick Start instructions for your operating system.
+Download and install [Google’s Cloud SDK](https://cloud.google.com/sdk/) using the installation and Quick Start instructions for your operating system.
 
-After installation, authentication and restarting your terminal, BigQuery’s command line tools are available in your shell. 
+After installation, authentication and restarting your terminal, BigQuery’s command line tools are available in your shell.
 
 Try the following query as an example:
 
-~~~sql
+~~~shell
 $ bq query --format=csv "
 -- Calculate how many NDT tests were performed per day since M-Lab epoch
 SELECT
@@ -71,18 +72,16 @@ ORDER BY
 
 If you are new to BigQuery, we suggest that you next consult the resources below to get started:
 
--   [Google’s BigQuery documentation](https://cloud.google.com/bigquery/what-is-bigquery)
--   [Google's bq Command-Line Tool Quickstart documentation](https://cloud.google.com/bigquery/bq-command-line-tool-quickstart)
+* [Google’s BigQuery documentation](https://cloud.google.com/bigquery/what-is-bigquery)
+* [Google's bq Command-Line Tool Quickstart documentation](https://cloud.google.com/bigquery/bq-command-line-tool-quickstart)
 
 ## BigQuery API
 
-Given the resources and expertise, you can develop your own application that uses M-Lab data. To learn more about building your own custom application in the [Google Cloud Platform documentation](https://cloud.google.com/docs/).
+Given the resources and expertise, you can develop your own application that uses M-Lab data. To learn more about building your own custom application, refer to the [Google Cloud Platform documentation](https://cloud.google.com/docs/).
 
-**Telescope** is an example of an application that M-Lab developed which uses the BigQuery Python API to download M-Lab data.
-
-[Telescope is available from M-Lab on Github](https://github.com/m-lab/telescope).
+**Telescope** is an example of an application that M-Lab developed which uses the BigQuery Python API to download M-Lab data. Telescope is available from M-Lab on [Github](https://github.com/m-lab/telescope).
 
 ## Further Reading
 
--   [BigQuery Examples](/data/bq/examples)
--   [BigQuery Schema](/data/bq/schema)
+* [BigQuery Examples](/data/bq/examples)
+* [BigQuery Schema](/data/bq/schema)

--- a/_pages/gcs.md
+++ b/_pages/gcs.md
@@ -5,21 +5,22 @@ permalink: /data/gcs/
 breadcrumb: data
 ---
 
-# Overview
+# Google Cloud Storage
+
 M-Lab publishes all data it collected in raw form as archives on Google Cloud Storage (GCS) at the following location:
 
 * [https://console.developers.google.com/storage/browser/m-lab/](https://console.developers.google.com/storage/browser/m-lab/)
 
-# File Layout
+## File Layout
 
 All M-Lab files are packaged up in compressed tarballs. They are placed in folders and named according to the following schema:
 
 `[tool]/[YYYY]/[MM]/[DD]/[YYYYMMDD]T[HHMMSS]-[server]-[tool]-[file index].tgz`
 
- * `tool`: The measurement tool that that generated the data.
- * `YYYYMMDDTHHMMSS`: Start of the time window in which the data was collected.
- * `server`: M-Lab server that collected the data.
- * `file index`: Index of the file.
+* `tool`: The measurement tool that that generated the data.
+* `YYYYMMDDTHHMMSS`: Start of the time window in which the data was collected.
+* `server`: M-Lab server that collected the data.
+* `file index`: Index of the file.
 
 This means that each tarball contains all the data collected during a single day, by a single tool running on a single M-Lab server.
 
@@ -27,7 +28,7 @@ If the data collected during one day by one tool on one server are more than 1GB
 
 For example, the tarball `20090218T000000Z-mlab1-lga01-ndt-0000.tgz` contains the first 1 GB of data collected by all the NDT tests that were served by the M-Lab server mlab1-lga01 on Feb 18, 2009.
 
-# Project Data
+## Project Data
 
 Direct links to each M-Lab project's raw data are available below:
 
@@ -64,9 +65,9 @@ Direct links to each M-Lab project's raw data are available below:
   * mlab-collectd is a monitoring tool for M-Lab slices that collects resource utilization information about all M-Lab servers.
   * More information is available on [Github](https://github.com/m-lab/collectd-mlab).
 
-# Accessing Data Programmatically
+## Accessing Data Programmatically
 
-## Accessing Data with `gsutil`
+### Accessing Data with `gsutil`
 
 The easiest way to access M-Lab data on GCS programmatically is by using the [`gsutil`](https://cloud.google.com/storage/docs/gsutil) command line utility.
 
@@ -78,7 +79,7 @@ $ gsutil ls -l gsutil ls -l gs://m-lab/
 $ gsutil cp gs://m-lab/ndt/2009/02/18/20090218T000000Z-mlab1-lga01-ndt-0000.tgz .
 ~~~
 
-## Accessing Data with Common HTTP Tools
+### Accessing Data with Common HTTP Tools
 
 The URLs shown in [M-Lab's GCS web interface](https://console.developers.google.com/storage/browser/m-lab/) require the user to be logged in, which can present challenges when attempting to access the data with common HTTP utilities like `curl` or `wget`.
 
@@ -100,7 +101,7 @@ You can access it without authentication via this URL:
 
 [https://storage.googleapis.com/m-lab/ndt/2015/12/28/20151228T000000Z-mlab1-lga04-ndt-0001.tgz](https://storage.googleapis.com/m-lab/ndt/2015/12/28/20151228T000000Z-mlab1-lga04-ndt-0001.tgz)
 
-## GCS File Index
+### GCS File Index
 
 A list of all M-Lab files in GCS is available at:
 


### PR DESCRIPTION
This change makes fixes to the data pages now that the style for
these pages is complete.

Specifically:
 * All pages now have a h1 of the page title
 * All pages only have a single h1
 * Linter errors are fixed (one is disabled because it's giving what
   seems to be a false positive with an erroneous line number)
 * Small fixes to wording/formatting where it seemed odd on review

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/98)
<!-- Reviewable:end -->
