### PR TITLE
Re-doing "quick link" anchors

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -12,7 +12,7 @@ layout: default
           	
   	{% for grid in page.grid-section %}
 
-		<li><a href="#{{ grid.group-heading | downcase | replace: " ", "-" }}" data-proofer-ignore><i class="icon icon-triangle icon-right icon-before"></i>{{ grid.group-heading }}</a></li>
+		<li><a href="#{{ grid.group-heading | downcase | replace: " — ", "--" | replace: " ", "-" }}" data-proofer-ignore><i class="icon icon-triangle icon-right icon-before"></i>{{ grid.group-heading }}</a></li> 
 
 		{% endfor %}
 
@@ -25,7 +25,7 @@ layout: default
           	
   	{% for link in col.column %}
 
-		<li><a href="#{{ link.group-heading | downcase | replace: " ", "-" }}" data-proofer-ignore><i class="icon icon-triangle icon-right icon-before"></i>{{ link.group-heading }}</a></li>
+		<li><a href="#{{ link.group-heading | downcase | replace: " — ", "--" | replace: " ", "-" }}" data-proofer-ignore><i class="icon icon-triangle icon-right icon-before"></i>{{ link.group-heading }}</a></li>
 
 		{% endfor %}
 

--- a/_pages/bigquery_examples.md
+++ b/_pages/bigquery_examples.md
@@ -3,6 +3,16 @@ layout: page
 title: "BigQuery Examples"
 permalink: /data/bq/examples/
 breadcrumb: data
+accordion-quick-links: true
+quick-links-section:
+  - column:
+    - group-heading: "Overview"
+    - group-heading: "Basic counting"
+    - group-heading: "Computing statistics over time"
+  - column:
+    - group-heading: "Dealing with IP addresses"
+    - group-heading: "Comparing NDT and NPAD tests"
+    - group-heading: "Computing distributions of tests across users"
 ---
 
 # BigQuery Examples

--- a/_pages/bigquery_examples.md
+++ b/_pages/bigquery_examples.md
@@ -6,13 +6,13 @@ breadcrumb: data
 accordion-quick-links: true
 quick-links-section:
   - column:
-    - group-heading: "Overview"
-    - group-heading: "Basic counting"
-    - group-heading: "Computing statistics over time"
+    - group-heading: "BigQuery Examples"
+    - group-heading: "Basic counting — How many users"
+    - group-heading: "Computing statistics over time — How many users per day"
   - column:
-    - group-heading: "Dealing with IP addresses"
-    - group-heading: "Comparing NDT and NPAD tests"
-    - group-heading: "Computing distributions of tests across users"
+    - group-heading: "Dealing with IP addresses — How many users from distinct subnets"
+    - group-heading: "Comparing NDT and NPAD tests — How many users have run both NDT and NPAD tests"
+    - group-heading: "Computing distributions of tests across users — How many users have run a certain number of tests"
 ---
 
 # BigQuery Examples

--- a/_pages/bigquery_quickstart.md
+++ b/_pages/bigquery_quickstart.md
@@ -3,6 +3,16 @@ layout: page
 title: "BigQuery QuickStart"
 permalink: /data/bq/quickstart/
 breadcrumb: data
+accordion-quick-links: true
+quick-links-section:
+  - column:
+    - group-heading: "BigQuery QuickStart"
+    - group-heading: "Configuring Access to M-Lab Data"
+    - group-heading: "BigQuery Web Interface"
+  - column:
+    - group-heading: "BigQuery tools in the Google Cloud SDK"
+    - group-heading: "BigQuery API"
+    - group-heading: "Further Reading"
 ---
 
 # BigQuery QuickStart

--- a/_pages/bigquery_schema.md
+++ b/_pages/bigquery_schema.md
@@ -3,6 +3,15 @@ layout: page
 title: "BigQuery Schema"
 permalink: /data/bq/schema/
 breadcrumb: data
+accordion-quick-links: true
+quick-links-section:
+  - column:
+    - group-heading: "BigQuery Schema"
+    - group-heading: "Background"
+    - group-heading: "BigQuery Tables"
+  - column:
+    - group-heading: "Schema Fields"
+    - group-heading: "Query Examples"
 ---
 
 # BigQuery Schema

--- a/_pages/faq.md
+++ b/_pages/faq.md
@@ -33,7 +33,6 @@ contact-accordion:
   - heading: "How can I contact M-Lab?"
 ---
 
-{:.general-questions}
 # General questions
 
 {% capture accordion_entry_1 %}
@@ -54,7 +53,6 @@ Measurement Lab (M-Lab) is an open, distributed server platform for researchers 
 
 {% include accordion.html acc_section = "gq" %}
 
-{:.i-am-an-internet-user-and-i-want-to-test-my-connection}
 # I am an internet user and I want to test my connection
 
 {% capture accordion_entry_1 %}
@@ -91,7 +89,6 @@ Right now, users can access 12 tools to measure their broadband connection speed
 
 {% include accordion.html acc_section = "iu" %}
 
-{:.i-am-a-researcher}
 # I am a researcher
 
 {% capture accordion_entry_1 %}
@@ -102,13 +99,11 @@ You can then prepare an application and [contact]({{ site.baseurl }}/contact/) t
 
 {% include accordion.html acc_section = "researcher" %}
 
-{:.i-am-a-company-or-institution}
 # I am a company or institution
 
 {% capture accordion_entry_1 %}
 Companies and institutions can help in a number of key ways, including:
 
-{:.disc-list}
 - Provide servers for the platform and purchase network connectivity.
 - Provide resources for data hosting, aggregation and publication.
 - Provide data analysis resources.
@@ -120,7 +115,6 @@ If you'd like to get involved as an M-Lab supporting partner, [contact]({{ site.
 
 {% include accordion.html acc_section = "company" %}
 
-{:.contact-mlab}
 # Contact MLab
 
 {% capture accordion_entry_1 %}

--- a/_pages/gcs.md
+++ b/_pages/gcs.md
@@ -6,7 +6,7 @@ breadcrumb: data
 accordion-quick-links: true
 quick-links-section:
   - column:
-    - group-heading: "Overview"
+    - group-heading: "Google Cloud Storage"
     - group-heading: "File Layout"
     - group-heading: "Project Data"
     - group-heading: "Accessing Data Programmatically"

--- a/_pages/gcs.md
+++ b/_pages/gcs.md
@@ -3,6 +3,13 @@ layout: page
 title: Google Cloud Storage
 permalink: /data/gcs/
 breadcrumb: data
+accordion-quick-links: true
+quick-links-section:
+  - column:
+    - group-heading: "Overview"
+    - group-heading: "File Layout"
+    - group-heading: "Project Data"
+    - group-heading: "Accessing Data Programmatically"
 ---
 
 # Google Cloud Storage

--- a/_sass/components/_quick-links.scss
+++ b/_sass/components/_quick-links.scss
@@ -1,8 +1,15 @@
 // Quick Links Navigational Component
 
 .quick-links {
-    width: 660px;
+  
+  &.l-span2 {
+    width: 100%;
     padding: 38px 0 0px;
+
+    .l-span1 {
+      width: 48%;
+    }
+  }
 
   > ul {
   	@include list_bullets(none, 0px, 10px, 20px);

--- a/css/base.scss
+++ b/css/base.scss
@@ -243,10 +243,6 @@ small {
     width: 630px
 }
 
-.l-span3 {
-    width: 100%
-}
-
 .l-grid {
     padding-bottom: 0
 }


### PR DESCRIPTION
## This PR supersedes pull #83 for adding anchor links to the data docs pages.  If we like this implementation then #83 can be closed as well as issue #77 .

As the lighter js has now been implemented into the site, this PR re-addresses the anchor link or table of content (TOC) capability on individual pages.  You will notice that an author no longer has to put in the `{:.anchor-classname}` syntax for each heading that should have an anchor.  An author does still need to specify each anchor in the yml frontmatter of each post however, and they **must match** the actual heading.  

If we want to avoid that yml frontmatter with these links, then we could implement either a jekyll plugin (won't work on gh-pages) or simple js that identifies headers on a page and dynamically inserts the TOC at the top of a page.  It would be possible to customize these to some degree (meaning show a TOC or not on each page as well as configure what headings should appear in a TOC sitewide) but we would need to define the business rule for that.  All headings in the TOC?  Only h2s?  h1s through h6s?

In the pages below, you will see that I did TOC links for H1s and H2s, but again, one advantage with the current implementation is it is completely customizable for each page.  The downside is additional manual work for an author.

Other notes to point out with this PR:
- You will see that with this implementation that the anchor links behave more intuitively and include the hash fragment in the URL when an anchor link is clicked.
- Needed to refactor the TOC logic in page.html slightly as there were headings with a dash in them which was causing issues with how kramdown is generating the heading ids.
- Some of the anchor links were quite long, so refactored the styling a tad to allow less wrapping of these links and attempting to utilize the space a little better.

These updates can be seen on my [fork](http://shredtechular.github.io/m-lab.github.io/).