### PR TITLE
Fix old or broken links on NDT test page.

### DIFF
--- a/_pages/tools/ndt.md
+++ b/_pages/tools/ndt.md
@@ -26,8 +26,6 @@ the NDT speed test".
 
 <p><iframe src="{{ site.baseurl }}/p/ndt-ws.html" width="750" height="500" align="middle"></iframe></p>
 
-**[Download command line client](https://code.google.com/p/ndt/source/){:.download-link .is-plain}**
-
 **Data** collected by NDT is available...
 
 - in raw format at <https://storage.cloud.google.com/m-lab/ndt>
@@ -38,10 +36,9 @@ the NDT speed test".
 - Please cite this dataset as follows: **The MLab NDT Dataset,
   &lt;date range used&gt;. http://measurementlab.net/tools/ndt**
 
-**Source code** is available at <http://code.google.com/p/ndt/source/>.
+**Source code** is available at <https://github.com/ndt-project/ndt/>.
 
-**More information** at <http://code.google.com/p/ndt/>
-and <http://www.internet2.edu/performance/ndt/>.
+**More information** at <http://software.internet2.edu/ndt/>.
 
 NOTE: if the test does not run or takes longer than 60 seconds,\
 please read the FAQ entry for "troubleshooting the NDT speed test".

--- a/_pages/tools/ndt.md
+++ b/_pages/tools/ndt.md
@@ -21,7 +21,7 @@ There are two supported ways to run an NDT test: via this web page below
 or via a Unix command-line tool.
 
 NOTE: if the test does not run or takes longer than 60 seconds, please
-read the [FAQ entry](http://measurementlab.net/faq) for "troubleshooting
+read the [FAQ entry](http://www.measurementlab.net/faq) for "troubleshooting
 the NDT speed test".
 
 <p><iframe src="{{ site.baseurl }}/p/ndt-ws.html" width="750" height="500" align="middle"></iframe></p>


### PR DESCRIPTION
* Links to the NDT source were still pointing to code.google.com, which is defunct.
* There was a link to "Download NDT client", but no such thing exists, and least not on the Internet2 site or Github, and the links simply pointed to the source, which was misleading.... so remove that link altogether.
* The "more information" bullet was pointing redundantly to the source, and also pointing to a page at internet2.org which no longer existed.
* The canonical M-Lab website address is prefixed with www, so all links should point to that domain.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/113)
<!-- Reviewable:end -->
