### PR TITLE
Force Travis build to fail when invalidating the CF cache fails.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,5 @@ before_install:
 after_success:
   # Only invalidate CloudFront cache if this on the master branch and is not a PR
   #if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-  cf-s3-inv || travis_terminate 1;
+  cf-s3-inv --key lol --secret rofl --distribution lolrofl || travis_terminate 1;
   #fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ before_install:
   if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     openssl aes-256-cbc -K $encrypted_69b240b11ca3_key -iv $encrypted_69b240b11ca3_iv -in _cf_s3_invalidator.yml.enc -out _cf_s3_invalidator.yml -d;
   fi
-after_success:
+after_deploy:
   # Only invalidate CloudFront cache if this on the master branch and is not a PR
-  #if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-  cf-s3-inv --key lol --secret rofl --distribution lolrofl || travis_terminate 1;
-  #fi
+  if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+    cf-s3-inv || travis_terminate 1;
+  fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ before_install:
   if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     openssl aes-256-cbc -K $encrypted_69b240b11ca3_key -iv $encrypted_69b240b11ca3_iv -in _cf_s3_invalidator.yml.enc -out _cf_s3_invalidator.yml -d;
   fi
-after_deploy:
+after_success:
   # Only invalidate CloudFront cache if this on the master branch and is not a PR
-  if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-    cf-s3-inv || travis_terminate 1;
-  fi
+  #if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+  cf-s3-inv || travis_terminate 1;
+  #fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,5 @@ before_install:
 after_deploy:
   # Only invalidate CloudFront cache if this on the master branch and is not a PR
   if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-    cf-s3-inv;
+    cf-s3-inv || travis_terminate 1;
   fi


### PR DESCRIPTION
The cf-s3-inv command failing after the deploy does not cause Travis to fail the whole build, yet we want any sort of failure to fail the whole thing, including if CloudFront cache invalidation fails.  This add an _|| travis_terminate 1_ after the _cf-s3-inv_ command with the idea that if cf-s3-inv fails it will force the entire Travis build to exit with a failing status (1).

An additional note is that I think I've corrected the reason for the failure in AWS.  Apparently the AWS user didn't have sufficient privileges...it needed cloudfront:GetDistribution permission (according to the error text), which the user now has.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/115)
<!-- Reviewable:end -->
