### PR TITLE
Auto-generation of Table of Contents

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,13 +19,18 @@ permalink: "/blog/:title/"
 sass:
   sass_dir: _sass
   style: compressed
-markdown: kramdown
 include: ['_pages']
 exclude:
   - .gitignore
   - README.md
   - Gemfile
   - Gemfile.lock
+
+# Markdown settings
+markdown: kramdown
+kramdown:
+  auto_ids:       true
+  auto_id_stripping:    true
 
 # Display blog posts even if they're future-dated.
 future: true

--- a/_pages/bigquery_examples.md
+++ b/_pages/bigquery_examples.md
@@ -5,6 +5,9 @@ permalink: /data/bq/examples/
 breadcrumb: data
 ---
 
+* Table of Contents
+{:toc}
+
 # BigQuery Examples
 
 The examples below query the M-Lab data in various ways to demonstrate effective use of the M-Lab BigQuery dataset.

--- a/_pages/bigquery_quickstart.md
+++ b/_pages/bigquery_quickstart.md
@@ -5,6 +5,9 @@ permalink: /data/bq/quickstart/
 breadcrumb: data
 ---
 
+* Table of Contents
+{:toc}
+
 # BigQuery QuickStart
 
 ## Configuring Access to M-Lab Data

--- a/_pages/bigquery_schema.md
+++ b/_pages/bigquery_schema.md
@@ -5,6 +5,9 @@ permalink: /data/bq/schema/
 breadcrumb: data
 ---
 
+* Table of Contents
+{:toc}
+
 # BigQuery Schema
 
 ## Background

--- a/_pages/faq.md
+++ b/_pages/faq.md
@@ -4,15 +4,6 @@ permalink: /faq/
 title: "FAQ"
 sub-nav: true
 breadcrumb: "about"
-accordion-quick-links: true
-quick-links-section:
-  - column:
-    - group-heading: "General Questions"
-    - group-heading: "I am an internet user and I want to test my connection"
-  - column:
-    - group-heading: "I am a researcher"
-    - group-heading: "I am a company or institution"
-    - group-heading: "Contact MLab"
 gq-accordion:
   - heading: "What and who are M-lab's supporting partners?"
   - heading: "What's M-Lab's origin story?"
@@ -33,7 +24,9 @@ contact-accordion:
   - heading: "How can I contact M-Lab?"
 ---
 
-{:.general-questions}
+* Table of Contents
+{:toc}
+
 # General questions
 
 {% capture accordion_entry_1 %}
@@ -54,7 +47,6 @@ Measurement Lab (M-Lab) is an open, distributed server platform for researchers 
 
 {% include accordion.html acc_section = "gq" %}
 
-{:.i-am-an-internet-user-and-i-want-to-test-my-connection}
 # I am an internet user and I want to test my connection
 
 {% capture accordion_entry_1 %}
@@ -91,7 +83,6 @@ Right now, users can access 12 tools to measure their broadband connection speed
 
 {% include accordion.html acc_section = "iu" %}
 
-{:.i-am-a-researcher}
 # I am a researcher
 
 {% capture accordion_entry_1 %}
@@ -102,25 +93,22 @@ You can then prepare an application and [contact]({{ site.baseurl }}/contact/) t
 
 {% include accordion.html acc_section = "researcher" %}
 
-{:.i-am-a-company-or-institution}
 # I am a company or institution
 
 {% capture accordion_entry_1 %}
 Companies and institutions can help in a number of key ways, including:
 
-{:.disc-list}
-- Provide servers for the platform and purchase network connectivity.
-- Provide resources for data hosting, aggregation and publication.
-- Provide data analysis resources.
-- Embed an M-Lab client-side tool in an application or service.
-- Provide funding to support the above.
+* Provide servers for the platform and purchase network connectivity.
+* Provide resources for data hosting, aggregation and publication.
+* Provide data analysis resources.
+* Embed an M-Lab client-side tool in an application or service.
+* Provide funding to support the above.
 
 If you'd like to get involved as an M-Lab supporting partner, [contact]({{ site.baseurl }}/contact/) the M-lab steering committee and join the [public mailing list](https://groups.google.com/a/measurementlab.net/forum/?fromgroups#!forum/discuss).
 {% endcapture %}
 
 {% include accordion.html acc_section = "company" %}
 
-{:.contact-mlab}
 # Contact MLab
 
 {% capture accordion_entry_1 %}

--- a/_pages/gcs.md
+++ b/_pages/gcs.md
@@ -5,6 +5,9 @@ permalink: /data/gcs/
 breadcrumb: data
 ---
 
+* Table of Contents
+{:toc}
+
 # Google Cloud Storage
 
 M-Lab publishes all data it collected in raw form as archives on Google Cloud Storage (GCS) at the following location:

--- a/_sass/components/_quick-links.scss
+++ b/_sass/components/_quick-links.scss
@@ -28,3 +28,43 @@
   }
 
 }
+
+ul#markdown-toc {
+  margin: 0px;
+  padding: 0px;
+
+  @include list_bullets(none, 0px, 10px, 20px);
+
+  li:before {
+    background:url("../images/sprites/globalSprite-1x.png") no-repeat -42px -128px;
+    width: 9px;
+    height: 15px;
+    display: block;
+    content: " ";
+    float: left;
+    padding-left: 10px;
+  }
+
+  > ul:last-child {
+    float: left;
+  }
+
+  a {
+    font-family: "Proxima Nova Semi Bold",Arial,Helvetica,sans-serif;
+    color: #454545;
+/*    background: url("../images/sprites/globalSprite-1x.png") no-repeat;
+    background-position: -42px -128px;
+    padding-left: 20px; */
+
+    &:hover {
+      color: #454545;
+    }
+
+    .icon-triangle {
+      float: left;
+      margin-bottom: 10px;
+      top: 3px;
+    }
+  }
+
+}

--- a/_sass/components/_quick-links.scss
+++ b/_sass/components/_quick-links.scss
@@ -1,8 +1,15 @@
 // Quick Links Navigational Component
 
 .quick-links {
-    width: 660px;
+
+  &.l-span2 {
+    width: 100%;
     padding: 38px 0 0px;
+
+    .l-span1 {
+      width: 48%;
+    }
+  }
 
   > ul {
   	@include list_bullets(none, 0px, 10px, 20px);
@@ -45,25 +52,12 @@ ul#markdown-toc {
     padding-left: 10px;
   }
 
-  > ul:last-child {
-    float: left;
-  }
-
   a {
     font-family: "Proxima Nova Semi Bold",Arial,Helvetica,sans-serif;
     color: #454545;
-/*    background: url("../images/sprites/globalSprite-1x.png") no-repeat;
-    background-position: -42px -128px;
-    padding-left: 20px; */
 
     &:hover {
       color: #454545;
-    }
-
-    .icon-triangle {
-      float: left;
-      margin-bottom: 10px;
-      top: 3px;
     }
   }
 

--- a/css/base.scss
+++ b/css/base.scss
@@ -243,10 +243,6 @@ small {
     width: 630px
 }
 
-.l-span3 {
-    width: 100%
-}
-
 .l-grid {
     padding-bottom: 0
 }


### PR DESCRIPTION
## This PR supersedes pull #83 and #110 for adding anchor links to the data docs pages.  If we like this implementation then these can be closed as well as issue #77 .

As the lighter js has now been implemented into the site, this PR re-addresses the anchor link or table of content (TOC) capability on individual pages.  You will notice that an author no longer has to put in the `{:.anchor-classname}` syntax for each heading that should have an anchor.  

You will also notice that an author does **NOT** need to specify each anchor in the yml frontmatter of each post either.

With this PR, if an author would like to display a Table Of Contents anywhere within their post, they can simply add the following to the markdown file:
```
* Table of Contents
{:toc}
```  

If an author needs more control over the customizing of the ToC, then they can use the existing format (as in the /tests/ page still using the old customized ToC).  For example, if it is desired to not show ToC links for certain h tags, this method can still be used for customization purposes.

If neither of those exist, then no ToC will be shown.

Other notes to point out with this PR:
- The auto-generated ToC will not split into 2 columns, this PR only supports 1 column ToC's.
- The auto-generated ToC does create indentation/nesting levels automatically as well depending on the H tag number.
- You will see that with this implementation that the anchor links behave more intuitively and include the hash fragment in the URL when an anchor link is clicked.
- Some of the anchor links were quite long, so refactored the styling a tad to allow less wrapping of these links and attempting to utilize the space a little better.

These updates can be seen on my [fork](http://shredtechular.github.io/m-lab.github.io/).

**To ensure the scope of this PR is understood, the following are planned for future PRs:**
- [ ] When clicking an accordion ToC link, the accordion automatically opens.
- [ ] GFM link icons to appear on left of H tags to let user know they can bookmark/go straight to that link
- [ ] Splitting into two columns if more than 4 and or scrollspy if desired in the future (dependency on bootstrap)
