### PR TITLE
Temporarily disabling external link checking in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
   - 2.2.3
 script:
-  - ./_tests/travis-checks
+  - ./_tests/travis-checks --quick
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer


### PR DESCRIPTION
ISC's web server is misconfigured to always return 404s even though the site is up, which causes htmlproofer to think we have dead links. Temporarily removing the external link check as a workaround.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/124)
<!-- Reviewable:end -->
