### PR TITLE
Bug - Observatory List Items

### DIFF
--- a/_layouts/observatory.html
+++ b/_layouts/observatory.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <div class="subpage-content full-width observatory-page">
-	<section class="intro-section">
+	<section id="intro-section-observatory">
 		<h1 class="section-heading">{{ page.heading }}</h1>
 
 		<div class="wrapper">

--- a/_sass/layouts/_body.scss
+++ b/_sass/layouts/_body.scss
@@ -15,3 +15,11 @@
     }
   }
 }
+
+#intro-section-observatory {
+	ul {
+		padding-left: 30px;
+
+    @include list_bullets(inherit, 0px, 0px, 24px, outside);
+  }
+}


### PR DESCRIPTION
Saw a bug come in that @georgiamoon caught and documented in issue #138.  Excellent catch BTW!

I think there are some other cases of conflicting styles happening between codebases on that page (i.e. - the main nav, no footer, etc), so we can probably tighten this up even more as well.  But this is one item that I know I introduced with the SASS styling cutover, so wanted to get this fix in at least since I know exactly what was causing that.

This fix changes the class to an id & renames it so we shouldn't have to worry about any specific classes for native pages overriding the submodules styling.  The only issue now would be base classes from each codebase, so needed to target the list items within that new section id to get it back to the intended submodule styling.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/139)
<!-- Reviewable:end -->
