### PR TITLE
Feature Responsive: 3 JS Event listeners for mobile menu

### DIFF
--- a/js/src/controllers/enhancers/NavigationEnhancer.js
+++ b/js/src/controllers/enhancers/NavigationEnhancer.js
@@ -42,6 +42,42 @@ function(
         }
       });
 
+      //minor event listener on mobile menu accordions to flip the arrow
+      // glyphicon depending if the particular accordion is open or closed.
+      $('.mobile-sub-nav').on('show.bs.collapse', function(){
+        $(this).parent().find(".glyphicon-triangle-bottom") 
+          .removeClass("glyphicon-triangle-bottom") 
+          .addClass("glyphicon-triangle-top");
+      }).on('hide.bs.collapse', function(){
+        $(this).parent().find(".glyphicon-triangle-top")
+          .removeClass("glyphicon-triangle-top") 
+          .addClass("glyphicon-triangle-bottom");
+      });
+
+      //click event logic that decides if a top level nav item follow the href
+      //link or act as an accordion since on desktop, it is just a link, but on
+      // mobile, it is an accordion.
+      $('.mobile-sub-nav-trigger').click( function(e) {
+          if ( $('#mobile-main-nav').is(":visible") ) {
+            e.preventDefault();
+            $(this).attr("href", "#"+$(this).attr("data-target"));
+
+            var parent = $(this).data('parent');
+            var actives = parent && $(parent).find('.collapse.in');
+
+            if (actives && actives.length) {
+                hasData = actives.data('collapse');
+                actives.collapse('hide');
+            }
+
+            $('#'+$(this).attr("data-target")).collapse('toggle');
+
+          } else {
+            $(this).attr("href", $(this).attr("data-link"));
+          }
+        }
+      );
+
     }
   };
 


### PR DESCRIPTION
This PR is the last piece to complete the responsive header behavior on the site.  It is a small js PR that accomplishes 2 things for the navigational menu to work properly.

1. The first chuck of the code below looks to see when the mobile navigational accordion is collapsed/expanded and switches the arrow glyphicon to up or down depending on the state of the particular accordion item.

2. The second chuck is a little more complex.  Since the green navigational menu is basically just a list of links on the desktop browsing of the site, yet on mobile it turns into an accordion (where if there is a submenu, it needs to expand and show the submenu items as opposed to going to the href link, we needed some javascript logic to determine which way to handle top level items that have submenus for both desktop & mobile versions of the nav menu.  

Basically, when a top level men item is clicked, then the js runs to check to see if the menu is in a "mobile" state by looking for a class that is only visible in the "mobile" state.  
-  If it sees that class, then it handles the click event using accordion functionality to collapse any open accordion panels and then open the item that was clicked.  
-  If it does *NOT* see that class, then it proceeds with the default href locational attribute.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/150)
<!-- Reviewable:end -->
