### PR TITLE
Feature Responsive: Layout & style updates for responsive body text

### DIFF
--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -30,7 +30,7 @@
   {% endfor %}
 {% endif %}
 
-<div class="subpage-content full-width {{ last_crumb | downcase }}-page">
+<div class="subpage-content col-xs-12 {{ last_crumb | downcase }}-page">
 <nav class="breadcrumbs">
   <a href="/" class="breadcrumb">Home</a> /
   

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -59,7 +59,6 @@
           {{ footer.privacy.blurb }}
         </div>
 
-
     </div>
   </div>
 </footer>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -2,46 +2,51 @@
 layout: default
 ---
 
-{% include breadcrumbs.html %}
-
 <meta data-id="enhancer" data-classname="SubPageEnhancer">
+<div class="container">
+	<div class="row">
 
-{% if page.grid-section and page.grid-quick-links %}
-<nav class="quick-links l-span2">
-	<ul class="l-span1">
-          	
-  	{% for grid in page.grid-section %}
+	{% include breadcrumbs.html %}
 
-		<li><a href="#{{ grid.group-heading | downcase | replace: " ", "-" }}" data-proofer-ignore><i class="icon icon-triangle icon-right icon-before"></i>{{ grid.group-heading }}</a></li>
+	{% if page.grid-section and page.grid-quick-links %}
+	<nav class="quick-links l-span2">
+		<ul class="l-span1">
+	          	
+	  	{% for grid in page.grid-section %}
 
+			<li><a href="#{{ grid.group-heading | downcase | replace: " ", "-" }}" data-proofer-ignore><i class="icon icon-triangle icon-right icon-before"></i>{{ grid.group-heading }}</a></li>
+
+			{% endfor %}
+
+		</ul>
+	</nav>
+	{% elsif page.accordion-quick-links %}
+	<nav class="quick-links l-span2">
+		{% for col in page.quick-links-section %}	
+		<ul class="l-span1">
+	          	
+	  	{% for link in col.column %}
+
+			<li><a href="#{{ link.group-heading | downcase | replace: " ", "-" }}" data-proofer-ignore><i class="icon icon-triangle icon-right icon-before"></i>{{ link.group-heading }}</a></li>
+
+			{% endfor %}
+
+		</ul>
 		{% endfor %}
+	</nav>
+	{% endif %}
 
-	</ul>
-</nav>
-{% elsif page.accordion-quick-links %}
-<nav class="quick-links l-span2">
-	{% for col in page.quick-links-section %}	
-	<ul class="l-span1">
-          	
-  	{% for link in col.column %}
+	<section class="intro-section">
 
-		<li><a href="#{{ link.group-heading | downcase | replace: " ", "-" }}" data-proofer-ignore><i class="icon icon-triangle icon-right icon-before"></i>{{ link.group-heading }}</a></li>
+	  {{ content }}
 
-		{% endfor %}
+	</section>
 
-	</ul>
-	{% endfor %}
-</nav>
-{% endif %}
+	{% if page.grid-section %}
+		{% include grid.html %}
+	{% endif %}
 
-<section class="intro-section">
+	</div><!--row-->
+</div><!--container-->
 
-  {{ content }}
-
-</section>
-
-{% if page.grid-section %}
-	{% include grid.html %}
-{% endif %}
-
-</div>
+</div><!--subpage-content-->

--- a/_sass/layouts/_body.scss
+++ b/_sass/layouts/_body.scss
@@ -1,39 +1,73 @@
 // main body layout elements
 
-.intro-section, .blog-entry {
-  ul {
-  	margin: 0px 0px 25px 15px;
-  	padding: 0px 0px 0px 15px;
+.subpage-content {
+  padding-top: 25px;
+  padding-bottom: 70px;
 
-    @include list_bullets(disc, 0px, 0px, 24px, outside);
+  h1 {
+    padding: 16px 0px;
+  }
 
-  	ul {
- 	    margin: 0px;
- 	    padding: 0px 0px 0px 15px;
+  p {
+    padding-bottom: 25px;
 
- 	    @include list_bullets(circle, 0px, 0px 0px 0px 15px, 24px, outside);
+    &:last-child {
+      padding-bottom: 0;
     }
   }
-}
 
-#intro-section-observatory {
-	ul {
-		padding-left: 30px;
+  h2 {
+    font-size: 16px;
+    line-height: 16px;
+    border-bottom: 1px solid #b7b7b7;
+    padding-bottom: 17px;
+    margin-bottom: 13px;
 
-    @include list_bullets(inherit, initial, initial, 24px, outside);
+    .tabbed-heading {
+      cursor: pointer;
+    }
+
   }
 
-  .helpContent ul.buttons {
-    padding: 0px;
+  .intro-section {
+    padding: 17px 0 0;
+  }
 
-    li {
-      padding: 10px 0;
+  .intro-section, .blog-entry {
+    ul {
+    	margin: 0px 0px 25px 15px;
+    	padding: 0px 0px 0px 15px;
 
-      &:first-child {
-        margin-left: 110px;
-        margin-right: 40px;
+      @include list_bullets(disc, 0px, 0px, 24px, outside);
+
+    	ul {
+   	    margin: 0px;
+   	    padding: 0px 0px 0px 15px;
+
+   	    @include list_bullets(circle, 0px, 0px 0px 0px 15px, 24px, outside);
       }
     }
   }
 
+  #intro-section-observatory {
+  	ul {
+  		padding-left: 30px;
+
+      @include list_bullets(inherit, initial, initial, 24px, outside);
+    }
+
+    .helpContent ul.buttons {
+      padding: 0px;
+
+      li {
+        padding: 10px 0;
+
+        &:first-child {
+          margin-left: 110px;
+          margin-right: 40px;
+        }
+      }
+    }
+  }
 }
+

--- a/css/base.scss
+++ b/css/base.scss
@@ -103,10 +103,6 @@ em, .italicised {
     min-height: 100%
 }
 
-#main {
-    padding-bottom: 290px
-}
-
 .img-ctn.img-left {
     text-align: left
 }
@@ -202,13 +198,6 @@ small {
     margin-right: 30px;
     display: inline;
     float: left
-}
-
-.full-width,.info-segment-inner {
-    width: 1000px;
-    margin: auto;
-    position: relative;
-    padding: 0 20px
 }
 
 .l-span1 {
@@ -1069,55 +1058,6 @@ label,.label {
     zoom:1;*display: inline;
     float: left;
     padding-right: 90px
-}
-
-.subpage-content {
-    padding: 25px 20px 70px
-}
-
-.subpage-content>section {
-    clear: both
-}
-
-.subpage-content h2 {
-    font-size: 16px;
-    line-height: 16px;
-    border-bottom: 1px solid #b7b7b7;
-    padding-bottom: 17px;
-    margin-bottom: 13px
-}
-
-.subpage-content h2 .sub-text {
-    color: #767676;
-    font-family: "Proxima Nova Regular",Arial,Helvetica,sans-serif
-}
-
-.subpage-content .definition-heading a {
-    color: #454545
-}
-
-.subpage-content .tabbed-heading {
-    cursor: pointer
-}
-
-.touch-device .subpage-content a:hover {
-    color: #e35343
-}
-
-.intro-section {
-    padding: 17px 0 0
-}
-
-.subpage-content h1 {
-    padding: 16px 0px;
-}
-
-.intro-section p {
-    padding-bottom: 25px
-}
-
-.intro-section p:last-child {
-    padding-bottom: 0
 }
 
 .info-section {


### PR DESCRIPTION
This PR adds layout and style updates for making the body text a bit more responsive.  

These changes can be previewed on my [fork](https://shredtechular.github.io/m-lab.github.io/).  You can now slowly change the width of your browser and all portions of actual body content/text breakdown to accompany the changing width of the viewing area.

Notes:
- This *merely* updates the main areas of the major content areas so that the content reflows according to browser width.
- This does *NOT* take into account more special elements like you see on the homepage, grids, tables, nothing with the blog layout, images, back to top etc.  This is just a first small step to getting the content areas of general pages to reflow nicely.
- Also included in this PR is an update to the footer file to remove an unnecessary blank line.  Figured I'd include in this PR since it was so minor.

Below are a few screen caps of how the responsiveness of the body text is looking at a few different breakpoints:

### Desktop:
<img width="1217" alt="screen shot 2016-04-06 at 9 50 31 am" src="https://cloud.githubusercontent.com/assets/2396774/14318984/60fd449c-fbdd-11e5-807e-b99833dfea3f.png">


### Tablet:
<img width="772" alt="screen shot 2016-04-06 at 9 50 52 am" src="https://cloud.githubusercontent.com/assets/2396774/14318991/670baaae-fbdd-11e5-9fba-654898058816.png">


#### Small Mobile/Phone:
<img width="397" alt="screen shot 2016-04-06 at 9 51 09 am" src="https://cloud.githubusercontent.com/assets/2396774/14318998/6d408dfe-fbdd-11e5-845f-08082e49a310.png">

