### PR TITLE
Feature Responsive: Update for anchors

### DIFF
--- a/_sass/components/_anchors.scss
+++ b/_sass/components/_anchors.scss
@@ -11,6 +11,11 @@
   margin-left: -20px;
   font-size: 20px;
 
+  @media screen and (max-width: $screen-sm-min) {
+    margin-left: -13px;
+    font-size: 18px;
+  }    
+
   &:after {
     content: attr(data-icon);
   }


### PR DESCRIPTION
This is a very minor update that will make anchors a little more responsive on mobile browser widths.  Users on mobile devices probably won't even see these, but folks that re-size their browsers may notice, so this style change makes the anchors fit a little more nicely on very small browser widths.

This change can be previewed on my [fork](https://shredtechular.github.io/m-lab.github.io/).

### Before:
<img width="397" alt="anchors_bad" src="https://cloud.githubusercontent.com/assets/2396774/14321032/853a5ff4-fbe5-11e5-9507-2c9a58083318.png">

### After:
<img width="399" alt="anchors-good" src="https://cloud.githubusercontent.com/assets/2396774/14321039/8bf9b20e-fbe5-11e5-873b-87b346cedd03.png">

