### PR TITLE
Feature Responsive: Blogs

### DIFF
--- a/_includes/siderail.html
+++ b/_includes/siderail.html
@@ -11,7 +11,7 @@
 {% endcomment %}
 
 <!-- Siderail -->
-<div class="blogroll-navigation l-span1 last">
+<div class="blogroll-navigation col-xs-12 col-sm-3 col-md-3 col-lg-2">
 
   <!-- Category Archives -->
   <div class="filter-col-ctn blog-cat-col">

--- a/_layouts/blog-archive.html
+++ b/_layouts/blog-archive.html
@@ -10,37 +10,48 @@ layout: default
   {% assign posts = site.posts %}
 {% endif %}
 
-{% include breadcrumbs.html %}
+<div class="container">
+  <div class="row">
 
-<div class="l-span2 blogroll">
+    {% include breadcrumbs.html %}
 
-{% for post in posts %}
+    <div class="container">
+      <div class="row">
+        <div class="col-xs-12 col-sm-9 col-md-9 col-lg-10 blogroll">
 
-  {% assign show-post = true %}
+        {% for post in posts %}
 
-  {% if page.archive-type == 'Monthly' %}
-    {% assign thisyear = post.date | date: "%B %Y" %}
-    {% if thisyear != page.archive-name %}
-      {% assign show-post = false %}
-    {% endif %}
-  {% endif %}
+          {% assign show-post = true %}
 
-  {% if show-post %}
+          {% if page.archive-type == 'Monthly' %}
+            {% assign thisyear = post.date | date: "%B %Y" %}
+            {% if thisyear != page.archive-name %}
+              {% assign show-post = false %}
+            {% endif %}
+          {% endif %}
 
-    <article class="blog-entry">
-      {% if post.content contains '<!--more-->' %}
-          {{ post.content | split:'<!--more-->' | first }}
-      {% else %}
-          {{ post.excerpt }}
-      {% endif %}
-      <p><a href="{{ site.baseurl }}{{ post.url }}" class="info-link">Read More</a></p>
-    </article>
+          {% if show-post %}
 
-  {% endif %}
+            <article class="blog-entry">
+              {% if post.content contains '<!--more-->' %}
+                  {{ post.content | split:'<!--more-->' | first }}
+              {% else %}
+                  {{ post.excerpt }}
+              {% endif %}
+              <p><a href="{{ site.baseurl }}{{ post.url }}" class="info-link">Read More</a></p>
+            </article>
 
-{% endfor %}
+          {% endif %}
 
-</div>
+        {% endfor %}
 
-{% include siderail.html %}
+        </div>
+
+        {% include siderail.html %}
+
+      </div><!--row-->
+    </div><!--container-->
+
+  </div><!--row-->
+</div><!--container-->
 

--- a/_layouts/blog-index.html
+++ b/_layouts/blog-index.html
@@ -2,51 +2,62 @@
 layout: default
 ---
 
-{% include breadcrumbs.html %}
+<div class="container">
+  <div class="row">
 
-<div class="l-span2 blogroll">
+    {% include breadcrumbs.html %}
 
-  {% for post in paginator.posts %}
+    <div class="container">
+      <div class="row">
+        <div class="col-xs-12 col-sm-9 col-md-9 col-lg-10 blogroll">
 
-  <article class="blog-entry">
+          {% for post in paginator.posts %}
 
-    {{ post.content }}
+          <article class="blog-entry">
 
-    <footer class="meta">
-      <small>Posted by <b class="author">{{ post.author }}</b> on <span class="published">{{ post.date | date: "%Y-%m-%d" }}</span> 
+            {{ post.content }}
 
-      {% if post.categories.size > 0 %}             
-        filed under 
-        <span class="categories">
+            <footer class="meta">
+              <small>Posted by <b class="author">{{ post.author }}</b> on <span class="published">{{ post.date | date: "%Y-%m-%d" }}</span> 
 
-        {% for cat in post.categories %}
-          <a href="{{ site.baseurl }}/blog/category/{{ cat | replace: ' ', '-' }}/">{{ cat }}</a>{% unless forloop.last %},{% endunless %}
-        {% endfor %}
+              {% if post.categories.size > 0 %}             
+                filed under 
+                <span class="categories">
 
-        </span>
-      {% endif %}
+                {% for cat in post.categories %}
+                  <a href="{{ site.baseurl }}/blog/category/{{ cat | replace: ' ', '-' }}/">{{ cat }}</a>{% unless forloop.last %},{% endunless %}
+                {% endfor %}
 
-      </small>
-    </footer>
+                </span>
+              {% endif %}
 
-  </article> <!-- .blog-entry -->
-  
-  {% endfor %}
+              </small>
+            </footer>
 
-  {% if paginator.total_pages > 1 %}
-  <ol class="pagination">
-    {% if paginator.next_page %}
-      <li><a href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}" class="next dir is-plain">Next<i class="icon icon-triangle icon-right icon-after"></i></a></li>
-    {% endif %}
+          </article> <!-- .blog-entry -->
+          
+          {% endfor %}
 
-    {% if paginator.previous_page %}
-      <li><a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}" class="previous dir is-plain"><i class="icon icon-triangle icon-left icon-before"></i>Previous</a></li>
-    {% endif %}
+          {% if paginator.total_pages > 1 %}
+          <ol class="pagination">
+            {% if paginator.next_page %}
+              <li><a href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}" class="next dir is-plain">Next<i class="icon icon-triangle icon-right icon-after"></i></a></li>
+            {% endif %}
 
-  </ol> <!-- .pagination -->
-  {% endif %}
+            {% if paginator.previous_page %}
+              <li><a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}" class="previous dir is-plain"><i class="icon icon-triangle icon-left icon-before"></i>Previous</a></li>
+            {% endif %}
 
-</div> <!-- .blogroll -->
+          </ol> <!-- .pagination -->
+          {% endif %}
 
-{% include siderail.html %}
+        </div> <!-- .blogroll -->
+
+        {% include siderail.html %}
+
+      </div><!--row-->
+    </div><!--container-->
+
+  </div><!--row-->
+</div><!--container-->
 

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -2,43 +2,54 @@
 layout: default
 ---
 
-{% include breadcrumbs.html %}
+<div class="container">
+  <div class="row">
 
-<div class="l-span2 blogroll">
+    {% include breadcrumbs.html %}
 
-  <article class="blog-entry">
+    <div class="container">
+      <div class="row">
+        <div class="col-xs-12 col-sm-9 col-md-9 col-lg-10 blogroll">
 
-    {{ content }}
+          <article class="blog-entry">
 
-    <footer class="meta">
-      <small>Posted by <b class="author">{{ page.author }}</b> on <span class="published">{{ page.date | date: "%Y-%m-%d" }}</span>
+            {{ content }}
 
-      {% if page.categories.size > 0 %}
-        <span class="categories">
-         filed under
+            <footer class="meta">
+              <small>Posted by <b class="author">{{ page.author }}</b> on <span class="published">{{ page.date | date: "%Y-%m-%d" }}</span>
 
-        {% for cat in page.categories %}
-          <a href="{{ site.baseurl }}/blog/category/{{ cat | replace: ' ', '-' }}/">{{ cat }}</a>{% unless forloop.last %},{% endunless %}
-        {% endfor %}
+              {% if page.categories.size > 0 %}
+                <span class="categories">
+                 filed under
 
-        </span>
-      {% endif %}
+                {% for cat in page.categories %}
+                  <a href="{{ site.baseurl }}/blog/category/{{ cat | replace: ' ', '-' }}/">{{ cat }}</a>{% unless forloop.last %},{% endunless %}
+                {% endfor %}
 
-      </small>
-    </footer>
+                </span>
+              {% endif %}
 
-  </article>
+              </small>
+            </footer>
+
+          </article>
 
 
-  <ol class="pagination">
-  
-    <li>{% if page.next.url %}<a href="{{ page.next.url | prepend: site.baseurl | replace: '//', '/' }}" class="next dir is-plain">Next<i class="icon icon-triangle icon-right icon-after"></i></a>{% endif %}</li>
-  
-    <li>{% if page.previous.url %}<a href="{{ page.previous.url | prepend: site.baseurl | replace: '//', '/' }}" class="previous dir is-plain"><i class="icon icon-triangle icon-left icon-before"></i>Previous</a>{% endif %}</li>
+          <ol class="pagination">
+          
+            <li>{% if page.next.url %}<a href="{{ page.next.url | prepend: site.baseurl | replace: '//', '/' }}" class="next dir is-plain">Next<i class="icon icon-triangle icon-right icon-after"></i></a>{% endif %}</li>
+          
+            <li>{% if page.previous.url %}<a href="{{ page.previous.url | prepend: site.baseurl | replace: '//', '/' }}" class="previous dir is-plain"><i class="icon icon-triangle icon-left icon-before"></i>Previous</a>{% endif %}</li>
 
-  </ol> <!-- .pagination -->
+          </ol> <!-- .pagination -->
 
-</div> <!-- .blogroll -->
+        </div> <!-- .blogroll -->
 
-{% include siderail.html %}
+        {% include siderail.html %}
 
+
+      </div><!--row-->
+    </div><!--container-->
+
+  </div><!--row-->
+</div><!--container-->

--- a/_posts/blog/2014-10-28-2014_interconnection_report.md
+++ b/_posts/blog/2014-10-28-2014_interconnection_report.md
@@ -13,7 +13,6 @@ categories:
 # ISP Interconnection and its Impact on Consumer Internet Performance: Introducing A New M-Lab Consortium Technical Report
 
 ![Sample graph from this report.]({{ site.baseurl }}/images/blog/cogent-from-lax-diurnal.png){:.pull-right}
-
 We are happy to announce the release of a long-term collaborative research effort using M-Lab’s data to understand how interconnection impacts end-user performance. The report, [ISP Interconnection and its Impact on Consumer Internet Performance]({{ site.baseurl }}/publications/M-Lab_Interconnection_Study_US.pdf) examines years of network measurement data from across the United States to determine the effects of network interconnection on the Internet performance of customers subscribing to specific access ISPs. Alongside this report, we are also pleased to release the [Internet Observatory]({{ site.baseurl }}//observatory) – a dynamic data visualization tool that will allow consumers, policymakers, and researchers to better understand the impact of ISP relationships on their own Internet access and performance. The Internet Observatory will be updated regularly, allowing future monitoring and comparison against past performance.
 
 <!--more-->

--- a/_posts/blog/2014-11-10-mlab-ripe.md
+++ b/_posts/blog/2014-11-10-mlab-ripe.md
@@ -12,7 +12,6 @@ categories:
 # M-Lab at RIPE
 
 ![RIPE 69 image]({{ site.baseurl }}/images/blog/ripe.png){:.pull-right width="294" height="206"}
-
 On Thursday Nov. 6, Collin Anderson gave a talk at the [RIPE meeting](http://www.ripe.net/ripe/meetings/ripe-meetings) in London. Collin has been immersed in the M-Lab data for some time, and helped lead the recently published technical report, [ISP Interconnection and its Impact on Consumer Internet Performance]({{ site.baseurl }}/publications/M-Lab_Interconnection_Study_US.pdf). He presented a lyrical overview of these research findings for the assembled crowd of network operators and researchers, which is archived on the RIPE website.
 
 <!--more-->

--- a/_sass/layouts/_blog.scss
+++ b/_sass/layouts/_blog.scss
@@ -1,0 +1,101 @@
+// blog layout elements
+
+.blog-page {
+    padding-bottom: 93px
+}
+
+.blog-entry {
+    border-bottom: 1px solid #b7b7b7;
+    padding-bottom: 17px;
+    margin-bottom: 28px;
+
+  p {
+    padding-bottom: 26px;
+
+    &.center {
+      text-align: center;
+    }
+
+    &::after {
+      @media screen and (min-width: $screen-lg-min){
+        clear: both;
+        content: "\0020";
+        display: block;
+        height: 0;
+        overflow: hidden;
+      }
+    }
+  }
+
+  img {
+    max-width: 100%;
+    width: auto;
+
+    .inherit-width {
+      max-width: inherit;
+    }
+
+    &::after {
+        clear: both;
+    }
+  }
+
+  .section-heading {
+    padding: 17px 0;
+  }
+
+  .meta {
+    padding-top: 14px;
+  }
+
+  .author {
+    font-family: "Proxima Nova Bold",Arial,Helvetica,sans-serif;
+  }
+
+  .visualisation-error {
+    padding: 0 10px;
+    position: relative;
+  }
+
+  .visualisation-error .error-text {
+    padding-left: 200px;
+
+    &::before {
+      float: none;
+      position: absolute;
+      left: 60px;
+      top: 45px
+    }
+  }
+
+  .blog-img {
+    display: block;
+  }
+
+  .pull-right {
+    @media screen and (max-width: $screen-xs-min) {
+      width: 100%;
+    }
+  }
+}
+
+.blogroll {
+  padding-left: 0px;
+}
+
+.blogroll-navigation {
+  margin-top: 20px;
+
+  h2 {
+    font-family: "Proxima Nova Regular",Arial,Helvetica,sans-serif
+  }
+
+  .filter-col-ctn {
+    margin-bottom: 35px;
+
+    a {
+      text-transform: capitalize;
+    }
+  }
+}
+

--- a/css/base.scss
+++ b/css/base.scss
@@ -18,6 +18,7 @@
 
 // Page specific layouts
 @import 'layouts/homepage';
+@import 'layouts/blog';
 
 // Include componets
 @import 'components/accordions';
@@ -838,87 +839,6 @@ label,.label {
     border-bottom: 0;
     padding: 0;
     margin: 0
-}
-
-.blog-page {
-    padding-bottom: 93px
-}
-
-
-
-.blog-entry {
-    border-bottom: 1px solid #b7b7b7;
-    padding-bottom: 17px;
-    margin-bottom: 28px
-}
-
-.blog-entry .section-heading {
-    padding: 17px 0
-}
-
-.blog-entry p {
-    padding-bottom: 26px
-}
-
-.blog-entry p.center {
-    text-align: center;
-}
-
-.blog-entry .meta {
-    padding-top: 14px
-}
-
-.blog-entry .author {
-    font-family: "Proxima Nova Bold",Arial,Helvetica,sans-serif
-}
-
-.blog-entry img {
-    max-width: 100%;
-    width: auto;
-}
-
-.blog-entry img.inherit-width {
-    max-width: inherit;
-}
-
-.blog-entry img.pull-right {
-    float: right;
-}
-
-.blog-entry .visualisation-error {
-    padding: 0 10px;
-    position: relative
-}
-
-.blog-entry .visualisation-error .error-text {
-    padding-left: 200px
-}
-
-.blog-entry .visualisation-error .error-text::before {
-    float: none;
-    position: absolute;
-    left: 60px;
-    top: 45px
-}
-
-.blog-img {
-    display: block
-}
-
-.blogroll-navigation {
-    margin-top: 20px
-}
-
-.blogroll-navigation h2 {
-    font-family: "Proxima Nova Regular",Arial,Helvetica,sans-serif
-}
-
-.blogroll-navigation .filter-col-ctn {
-    margin-bottom: 35px
-}
-
-.blogroll-navigation .filter-col a {
-    text-transform: capitalize;
 }
 
 .filter-col {


### PR DESCRIPTION
This PR adds layout and style updates for making the blog layouts (index, archive, and single blog pages) responsive.  

These changes can be previewed on my [fork](https://shredtechular.github.io/m-lab.github.io/) and you can test the responsive nature of all the blog layouts.

Notes:
- Probably the biggest design decision with this PR is what to do with the blog sidebar when it breaks down to very small viewing widths.  In my opinion, the best option, short term, is to have the sidebar collapse underneath the content.  The content is more important than the sidebar and I think it is okay that the sidebar displays underneath so a user can still use that as a navigational tool.  Future considerations might include more fancier solutions, some that I can think of below are:
    - Slide the sidebar out from the side when a button is clicked.  This might be the nicest solution, but probably a heavier LOE.
    - Maybe have a couple of dropdowns or accordions at the top for the 2 blog sidebar nav items?  Though,  I fear this could get a little confusing with the overall nav menu?
    - We could hide the sidebar altogether as well, if folks think its just not useful for mobile users?  Figured best to keep for now and just stack underneath.
- There were a couple of blog items that I tweaked the markdown on to get a couple of the images that are offset to the right to display a little nicer across all breakpoints.  They were really minor tweaks, but wanted to call that out as you will see a couple edits in .md files.
- [ ] One of the blogs has a table in it that isn't fully responsive yet.  This will come in a future PR.

Other than that, all the blogs are finished with this PR!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/158)
<!-- Reviewable:end -->
