### PR TITLE
Feature Responsive: Grids

### DIFF
--- a/_includes/grid.html
+++ b/_includes/grid.html
@@ -25,36 +25,41 @@
 
 {% if page.grid-section %}
   {% for grid in page.grid-section %}
+  <div class="container">
+    <section class="info-section grid-section first-child {{ grid.group-heading | downcase | replace: " ", "-" }}">
+    <div class="row">
+      <h2 class="grid-header col-xs-12" id="{{ grid.group-heading | downcase | replace: " ", "-" }}">{{ grid.group-heading }}</h2>
+    </div>
+    <div class="row">
+      <ul class="{{ grid.group-list-class }}">
 
-  <section class="info-section grid-section first-child {{ grid.group-heading | downcase | replace: " ", "-" }}">
-    <h2 class="grid-header" id="{{ grid.group-heading | downcase | replace: " ", "-" }}">{{ grid.group-heading }}</h2>
-    <ul class="{{ grid.group-list-class }}">
+        {% for item in grid.grid-items %}
+        <li{% if grid.group-list-class == "l-grid l-3col" %} class="grid-group col-xs-12 col-sm-6 col-md-4 col-lg-3"{% endif %}>
 
-      {% for item in grid.grid-items %}
-      <li{% if grid.group-list-class == "l-grid l-3col" %} class="grid-group"{% endif %}>
-
-        {% if item.link %}
-        <a href="{% if item.link | slice: 0 = "/" %}{{ item.link | prepend: site.baseurl }}{% else %}{{ item.link }}{% endif %}" class="grid-link is-plain">
-        {% endif %}
-
-          {% if grid.group-list-class == "l-grid l-3col" %}
-          <div class="grid-img{{ grid.grid-img-class }}"><img src="{{ site.baseurl }}/images{{ img_dir }}/{{ item.image }}" alt="{{ item.heading }}" class=""></div>
-          <div class="grid-info">
-            <h3 class="grid-heading">{{ item.heading }}</h3>
-            <div class="grid-description"><p>{{ item.desc }}</p></div>
-          </div>
-          {% else %}
-          <img src="{{ site.baseurl }}/images{{ img_dir }}/{{ item.image }}" alt="{{ item.alt }}" class="grid-link is-plain">
+          {% if item.link %}
+          <a href="{% if item.link | slice: 0 = "/" %}{{ item.link | prepend: site.baseurl }}{% else %}{{ item.link }}{% endif %}" class="grid-link is-plain">
           {% endif %}
-        
-        {% if item.link %}
-        </a>
-        {% endif %}
-      </li>
-      {% endfor %}
 
-    </ul>
-  </section>
+            {% if grid.group-list-class == "l-grid l-3col" %}
+            <div class="grid-img{{ grid.grid-img-class }}"><img src="{{ site.baseurl }}/images{{ img_dir }}/{{ item.image }}" alt="{{ item.heading }}" class=""></div>
+            <div class="grid-info">
+              <h3 class="grid-heading">{{ item.heading }}</h3>
+              <div class="grid-description"><p>{{ item.desc }}</p></div>
+            </div>
+            {% else %}
+            <img src="{{ site.baseurl }}/images{{ img_dir }}/{{ item.image }}" alt="{{ item.alt }}" class="grid-link is-plain">
+            {% endif %}
+          
+          {% if item.link %}
+          </a>
+          {% endif %}
+        </li>
+        {% endfor %}
 
+      </ul>
+    </div>
+    </section>
+  </div>
   {% endfor %}
+
 {% endif %}

--- a/_sass/components/_grids.scss
+++ b/_sass/components/_grids.scss
@@ -11,8 +11,12 @@
     padding-top: 40px;
   }
 
-  > .grid-header {
-    margin-bottom: 30px;
+  .grid-header {
+    padding-left: 0px;
+  }
+
+  .grid-group {
+    padding-top: 20px;
   }
 
   .grid-link {
@@ -45,6 +49,9 @@
     overflow: hidden;
     line-height: 104px;
     text-align: center;
+    float: left;
+    display: block;
+    margin-right: 10px;
 
     &.framed {
       width: 102px;
@@ -69,7 +76,6 @@
   }
 
   .grid-info {
-    width: 190px;
 
     .grid-heading {
       font-size: 16px;

--- a/css/base.scss
+++ b/css/base.scss
@@ -57,20 +57,6 @@ article,aside,details,figcaption,figure,hgroup,menu,section,summary {
     display: block
 }
 
-.clearfix,.l-grid,.quick-links,.grid-section .grid-link,.subpage-content {
-    zoom:1}
-
-.clearfix:before,.l-grid:before,.quick-links:before,.grid-section .grid-link:before,.subpage-content:before,.clearfix:after,.l-grid:after,.quick-links:after,.grid-section .grid-link:after,.subpage-content:after {
-    content: "\0020";
-    display: block;
-    height: 0;
-    overflow: hidden
-}
-
-.clearfix:after,.l-grid:after,.quick-links:after,.grid-section .grid-link:after,.subpage-content:after {
-    clear: both
-}
-
 .ir,.btn-social,.btn-lang,.main-logo a,.flex-control-nav>li a {
     display: block;
     text-indent: -999em;
@@ -78,6 +64,17 @@ article,aside,details,figcaption,figure,hgroup,menu,section,summary {
     background-repeat: no-repeat;
     text-align: left;
     direction: ltr
+}
+
+.quick-links:before,.quick-links:after {
+    content: "\0020";
+    display: block;
+    height: 0;
+    overflow: hidden
+}
+
+.quick-links:after {
+    clear: both
 }
 
 em, .italicised {
@@ -190,91 +187,6 @@ small {
 
 ::-moz-selection {
     background: rgba(175,219,210,0.7)
-}
-
-.l-span1,.l-span2,.l-grid.l-2col>li,.l-grid.l-3col>li,.l-grid.l-multi-col>li {
-    margin-right: 30px;
-    display: inline;
-    float: left
-}
-
-.l-span1 {
-    width: 300px
-}
-
-.l-span1:last-child,.l-span1.last {
-    float: right;
-    margin-right: 0
-}
-
-.l-span2 {
-    width: 630px
-}
-
-.l-grid {
-    padding-bottom: 0
-}
-
-.l-grid>li {
-    padding-bottom: 24px
-}
-
-.l-grid>li a {
-    display: block
-}
-
-.l-grid .grid-img {
-    display: block
-}
-
-.l-grid.l-2col>li {
-    width: 465px;
-    margin-right: 15px
-}
-
-.l-grid.l-2col>li:nth-child(even) {
-    float: right;
-    margin-right: 0
-}
-
-.l-grid.l-2col>li .grid-img {
-    width: 135px
-}
-
-.l-grid.l-2col>li .grid-info {
-    width: 300px
-}
-
-.l-grid.l-3col>li {
-    width: 300px;
-    margin-right: 30px
-}
-
-.l-grid.l-3col>li:nth-child(3n) {
-    float: right;
-    margin-right: 0
-}
-
-.l-grid.l-multi-col>li {
-    margin-right: 30px
-}
-
-.l-grid.l-multi-col>li:nth-child(9n) {
-    margin-right: 0
-}
-
-.l-grid.l-multi-col img {
-    display: block;
-    line-height: 0
-}
-
-.l-grid .grid-img {
-    float: left;
-    line-height: 0
-}
-
-.l-grid .grid-info {
-    float: right
 }
 
 .sub-heading-link {
@@ -617,14 +529,6 @@ ol ol {
     padding-bottom: 0
 }
 
-.thumb-grid {
-    padding-top: 74px
-}
-
-.thumb-grid:first-child,.thumb-grid.first-child {
-    padding-top: 40px
-}
-
 input[type=text],input[type=email],.select-choice,.textarea {
     border: 1px solid #b7b7b7;
     width: 100%;
@@ -918,36 +822,12 @@ label,.label {
     margin-bottom: 0
 }
 
-.about-page .learn-more-grid {
-    padding-top: 40px
-}
-
 .about-h2 {
     margin-top: 20px;
 }
 
 .about-h3 {
     color:#767676;
-}
-
-.l-grid h3 {
-    color: #767676
-}
-
-.tests-page .subpage-content {
-    padding-bottom: 76px
-}
-
-.tests-page .grid-section {
-    padding-top: 23px
-}
-
-.tests-page .grid-section:first-child {
-    padding-top: 40px
-}
-
-.tests-page .about-tests-section {
-    padding: 40px 0 22px
 }
 
 .flat-page .accordion-content {


### PR DESCRIPTION
This PR adds layout and style updates for making "grids" on the website responsive.  Currently grids are found on the /tests/ and /who/ pages.

These changes can be previewed on my [fork](https://shredtechular.github.io/m-lab.github.io/).

Below are a few screen caps to provide a quick look at how the responsiveness of the grids is looking at a few different breakpoints:

### Desktop:
<img width="1228" alt="screen shot 2016-04-07 at 3 29 42 pm" src="https://cloud.githubusercontent.com/assets/2396774/14364204/d5be480a-fcd5-11e5-91ec-21dffc877782.png">

### Tablet (landscape mode):
<img width="850" alt="screen shot 2016-04-07 at 3 30 32 pm" src="https://cloud.githubusercontent.com/assets/2396774/14364218/e20c44cc-fcd5-11e5-83ef-bb69bcc5f3e9.png">

### Tablet (portrait mode)
<img width="1012" alt="screen shot 2016-04-07 at 3 30 08 pm" src="https://cloud.githubusercontent.com/assets/2396774/14364212/dc927d36-fcd5-11e5-8c20-3d6a2d9b7021.png">

#### Small Mobile/Phone:
<img width="460" alt="screen shot 2016-04-07 at 3 30 58 pm" src="https://cloud.githubusercontent.com/assets/2396774/14364239/fa024c98-fcd5-11e5-85e6-bfcd318891da.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/160)
<!-- Reviewable:end -->
