### PR TITLE
Feature Responsive: Bootstrap Data Tables Capability

### DIFF
--- a/_pages/bigquery_schema.md
+++ b/_pages/bigquery_schema.md
@@ -42,6 +42,8 @@ M-Lab continues to support these tables, but urges clients to move to the new pe
 
 All M-Lab data shares the same data schema in BigQuery. The fields are described in the table below:
 
+<div class="table-responsive" markdown="1">
+
 | Field name                                           |     Type     |  Description                              |
 | :----------------------------------------------------|:------------:|:------------------------------------------|
 | `test_id`                                           |  `string`    |  ID of the test. It represents the filename of the log that contains the data generated during the test (e.g. `20090819T02:01:04.507508000Z_189.6.232.77:3859.c2s_snaplog.gz`). |
@@ -98,6 +100,8 @@ All M-Lab data shares the same data schema in BigQuery. The fields are described
 | `paris_traceroute_hop.dest_af`                      |  `integer`   |  The address family used to connect to `dest_ip`.<br>AF_INET = `2`<br>AF_INET6 = `10`. |
 | `paris_traceroute_hop.dest_hostname`                |  `string`    |  The hostname of the end of the hop. This may be the same as `dest_ip` if the hostname could not be resolved. |
 | `paris_traceroute_hop.rtt`                          |  `float`     |  The RTT measured from `connection_spec.server_ip` to `paris_traceroute_hop.dest_ip`. |
+
+</div>
 
 ### Deprecated Fields
 

--- a/_sass/base/_base.scss
+++ b/_sass/base/_base.scss
@@ -23,6 +23,10 @@ table {
   border-collapse: collapse;
   border-spacing: 0;
   margin: 0px 0px 30px 0px;
+
+  @media screen and (max-width: $screen-sm-min){
+    margin: 0px;
+  }
 }
 
 caption,th,td {

--- a/_sass/components/_tables.scss
+++ b/_sass/components/_tables.scss
@@ -1,9 +1,3 @@
 // Table component
 
 
-// Customized bigquery table
-.bigquery.schema-page table {
-  @media screen and (max-width: $screen-md-min){
-    word-break: break-all;
-  }
-}


### PR DESCRIPTION
Per comments in https://github.com/m-lab/m-lab.github.io/pull/159, this moves the solution for bigger responsive tables to bootstrap's responsive tables solution.

This removes the existing larger table's css to not break lines in the middle of a word and then in order to use bootstrap's solution, you can see it is enabled by wrapping a table in a `<div class="table-responsive" markdown="1"></div>` div.  The `markdown="1"` is critical to making the markdown'ed table render properly.  So, this will need to be enabled on a case-by-case basis as authors create/edit data tables on the site, so it does complicate the markdown a little.  But it will enable horizontal scrolling for large data tables.

I have put this up on my [fork](http://shredtechular.github.io/m-lab.github.io/) to be previewed if this solution is desired for large responsive data tables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/173)
<!-- Reviewable:end -->
