### PR TITLE
Bug - FAQ Image Responsiveness

### DIFF
--- a/_sass/base/_base.scss
+++ b/_sass/base/_base.scss
@@ -110,6 +110,11 @@ small {
     display: block
 }
 
+img {
+  max-width: 100%; 
+  display:block; 
+}
+
 ::selection {
     background: rgba(175,219,210,0.7)
 }


### PR DESCRIPTION
This PR is a bug fix for issue #176 where the image on the page is not scaling properly as the browsing size changes.

The fix adds base img CSS to set a max-width so images don't scale up beyond intention, yet scale down properly.  I think this is the best solution as making authors add the img-responsive bootstrap class to specific images could be mishandled.

This fix is previewable on my [fork](http://shredtechular.github.io/m-lab.github.io/faq/) and below is a screen cap of the fix on mobile widths:

<img width="390" alt="screen shot 2016-04-11 at 6 17 49 pm" src="https://cloud.githubusercontent.com/assets/2396774/14444140/d4978a38-0011-11e6-8877-3b259450a22e.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/180)
<!-- Reviewable:end -->
