### PR TITLE
Bug - Data Table Padding

### DIFF
--- a/_sass/base/_base.scss
+++ b/_sass/base/_base.scss
@@ -49,10 +49,6 @@ table {
   border-collapse: collapse;
   border-spacing: 0;
   margin: 0px 0px 30px 0px;
-
-  @media screen and (max-width: $screen-sm-min){
-    margin: 0px;
-  }
 }
 
 caption,th,td {

--- a/_sass/components/_tables.scss
+++ b/_sass/components/_tables.scss
@@ -1,3 +1,9 @@
 // Table component
 
 
+// To allow for bootstrap scroll bars on large tables, set table margin to 0
+.table-responsive table {
+  @media screen and (max-width: $screen-sm-min){
+    margin: 0px;
+  }
+}


### PR DESCRIPTION
This PR is a fix for issue #178 which was an issue with padding on tables on mobile device browsing widths.

I mistakenly added a zero margin on the sm breakpoint for ALL tables instead of just the large tables that have the ``table-responsive`` class wrapper.  This CSS fix remedies the issue to only apply that 0 margin to those specific data tables since those have extra margin due to scroll bars that bootstrap provides.

This change is previewable on my [fork](http://shredtechular.github.io/m-lab.github.io/data/bq/examples/) and a below screen capture to illustrate the fix:

<img width="398" alt="screen shot 2016-04-11 at 6 42 34 pm" src="https://cloud.githubusercontent.com/assets/2396774/14444701/43c4201c-0015-11e6-9bfd-148594b0cf19.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/181)
<!-- Reviewable:end -->
