### PR TITLE
Feature Responsive: Making NDT test responsive

### DIFF
--- a/_layouts/ndt-test.html
+++ b/_layouts/ndt-test.html
@@ -69,11 +69,10 @@
       <div id="download" class="test">
         <h2 class="centered">Now testing your <em>download speed</em></h2>
       </div>
-      <canvas id="uploadGauge"></canvas>
-      <div id="rtt">RTT
-        <div id="rttValue"></div>
+      <div class="guage-container">
+          <canvas id="uploadGauge"></canvas>
+          <canvas id="downloadGauge"></canvas>
       </div>
-      <canvas id="downloadGauge"></canvas>
       <div class="locations">
         <div class="local location"></div>
         <div class="remote location">
@@ -83,12 +82,19 @@
       </div>
     </div>
     <div id="results" class="summary page">
-      <h2>Your test results</h2>
-      <div class="view-selector">
-        <span class="summary button">Summary</span>
-        <span class="details button">Details</span>
-        <span class="advanced button">Advanced</span>
+      <div>
+        <div class="title-container">
+          <h2>Your test results</h2>
+        </div>
+        <div class="view-selector-container">
+          <div class="view-selector">
+            <span class="summary button">Summary</span>
+            <span class="details button">Details</span>
+            <span class="advanced button">Advanced</span>
+          </div>
+        </div>
       </div>
+      <div class="clearfix"></div>
       <div id="result-pages">
         <div class="result-page summary">
           <div class="upload result">

--- a/_pages/tools/ndt.md
+++ b/_pages/tools/ndt.md
@@ -24,7 +24,7 @@ NOTE: if the test does not run or takes longer than 60 seconds, please
 read the [FAQ entry](http://www.measurementlab.net/faq) for "troubleshooting
 the NDT speed test".
 
-<p><iframe src="{{ site.baseurl }}/p/ndt-ws.html" width="750" height="500" align="middle"></iframe></p>
+<div class="embed-responsive embed-responsive-4by3 ndt-iframe"><iframe src="{{ site.baseurl }}/p/ndt-ws.html" align="middle" class="embed-responsive-item"></iframe></div>
 
 **Data** collected by NDT is available...
 
@@ -42,3 +42,5 @@ the NDT speed test".
 
 NOTE: if the test does not run or takes longer than 60 seconds,\
 please read the FAQ entry for "troubleshooting the NDT speed test".
+
+

--- a/_sass/components/_iframes.scss
+++ b/_sass/components/_iframes.scss
@@ -1,7 +1,9 @@
 // Individual iframes component
 
 .ndt-iframe {
-	min-height: 500px;
-	padding-bottom: 54%;
-	margin-bottom: 20px;
+  min-height: 500px;
+  padding-bottom: 54%;
+  margin-bottom: 20px;
+  -webkit-overflow-scrolling: touch;
+  overflow-y: scroll;
 }

--- a/_sass/components/_iframes.scss
+++ b/_sass/components/_iframes.scss
@@ -1,0 +1,7 @@
+// Individual iframes component
+
+.ndt-iframe {
+	min-height: 500px;
+	padding-bottom: 54%;
+	margin-bottom: 20px;
+}

--- a/css/base.scss
+++ b/css/base.scss
@@ -29,6 +29,7 @@
 @import 'components/carousel';
 @import 'components/errors';
 @import 'components/icons';
+@import 'components/iframes';
 @import 'components/links';
 @import 'components/quick-links';
 @import 'components/grids';

--- a/css/ndt-test.css
+++ b/css/ndt-test.css
@@ -7,25 +7,28 @@ body {
   margin: 0;
   padding: 0;
   border: 0;
-  overflow: hidden;
-  height: 2000px;
 }
 
 a img {
   border: 0;
 }
 
+.clearfix {
+  clear:both;
+}
+
 #widget {
   position: relative;
-  width: 720px;
-  height: 480px;
+  width: 100%;
   overflow: hidden;
-  background-color: black;
   color: white;
   text-transform: uppercase;
   font-size: 36px;
   font-family: "League Gothic", Impact, "Arial Narrow", sans-serif;
   margin-bottom: 15px;
+  text-align: center;
+  margin: 0px auto;
+  max-width: 750px;
 }
 
 .header {
@@ -43,18 +46,14 @@ a img {
 }
 
 #start-button {
-  padding-top: 180px;
+  padding-top: 180px; 
 }
 
 .page {
-  width: 640px;
-  height: 420px;
-  position: absolute;
-  left: 0;
-  top: 0;
-  padding: 40px;
+  position: relative;
   background-color: #fff;
   color: #000;
+  margin: 20px;
 }
 
 #welcome {
@@ -135,10 +134,7 @@ h3 {
 
 .page .status,
 .page .controls {
-  width: 640px;
-  position: absolute;
-  left: 40px;
-  bottom: 40px;
+  position: relative;
   text-align: center;
 }
 
@@ -172,27 +168,20 @@ body.initializing .page .status {
 }
 
 #test .locations {
-  width: 640px;
-  position: absolute;
-  left: 40px;
-  top: 400px;
   font-size: 32px;
   line-height: 32px;
 }
 
 #test .location {
-  position: absolute;
   top: 0;
 }
 
 #test .location.local {
-  right: 0;
   text-align: right;
 }
 
 #test .location.remote {
-  left: 0;
-  text-align: left;
+  text-align: center;
 }
 
 #test .location .address {
@@ -201,26 +190,13 @@ body.initializing .page .status {
   font: bold 13px/13px verdana, helvetica, arial, sans-serif;
 }
 
-#uploadGauge {
-  position: absolute;
-  left: 40px;
-  top: 120px;
-  overflow: hidden;
+.gauge-container {
+  width:100%;
+  text-align:center;
+  margin-top:20px;
 }
-
-#downloadGauge {
-  position: absolute;
-  left: 380px;
-  top: 120px;
-  overflow: hidden;
-}
-
-#rtt {
-  position: absolute;
-  left: 320px;
-  top: 320px;
-  color: white;
-  font: bold 20px/20px verdana, helvetica, arial, sans-serif;
+#uploadGauge, #downloadGauge {
+  width: 45%;
 }
 
 #rttValue {
@@ -231,31 +207,31 @@ body.initializing .page .status {
   color: black;
 }
 
-#results {
-  height: 400px;
-}
-
 #result-pages {
-  width: 640px;
-  height: 280px;
-  position: absolute;
-  left: 40px;
-  top: 100px;
+  text-align: center;
+  width: 100%;
 }
 
 #result-pages .result-page {
-  width: 640px;
-  height: 280px;
-  position: absolute;
-  left: 0;
-  top: 0;
   display: none;
 }
 
-#results.summary #result-pages .result-page.summary,
+#results.summary #result-pages .result-page.summary {
+  display: table;
+  border-spacing: 10px 0px;
+  border-collapse: collapse;
+  position: relative;
+  margin: 20px 0px;
+  width: 100%;
+}
+
 #results.details #result-pages .result-page.details,
 #results.advanced #result-pages .result-page.advanced {
   display: block;
+  text-align: left;
+  position: relative;
+  margin: 20px 0px;
+  width: 100%;
 }
 
 #result-pages .details, #result-pages .advanced {
@@ -269,12 +245,19 @@ body.initializing .page .status {
 }
 
 #results .result {
-  width: 268px;
-  height: 180px;
-  position: absolute;
-  top: 0px;
-  padding: 20px;
   border: 1px solid #ccc;
+  width: 50%;
+  padding: 10px;
+  display: table-cell;
+}
+
+#results .title-container {
+  float:left;
+  text-align:left;
+}
+
+#results .result p {
+  margin: 0px;
 }
 
 #results .result .number {
@@ -287,32 +270,23 @@ body.initializing .page .status {
   text-transform: none;
 }
 
-#results .upload {
-  left: 0;
-}
-
-#results .download {
-  right: 0;
+#results .result h3 {
+  padding-top: 15px;
 }
 
 #results .other {
-  position: absolute;
-  top: 240px;
   text-transform: none;
   font: 13px/18px verdana, arial, helvetica, sans-serif;
+  text-align: left;
+  display: table-caption;
+  caption-side: bottom;
 }
 
 #results .controls {
-  width: 320px;
-  left: 360px;
   text-align: right;
 }
 
 #results .branding {
-  position: absolute;
-  width: 320px;
-  left: 40px;
-  bottom: 24px;
   text-transform: none;
   font: 11px/16px verdana, arial, helvetica, sans-serif;
 }
@@ -321,12 +295,14 @@ body.initializing .page .status {
   color: black;
 }
 
+#results .view-selector-container {
+  float:right;
+  text-align:right;
+}
+
 #results .view-selector {
-  position: absolute;
-  right: 40px;
-  top: 60px;
   font-size: 18px;
-  line-height: 18px;
+  padding-top: 15px;
 }
 
 #results .view-selector .summary {
@@ -358,4 +334,60 @@ body.initializing .page .status {
 #results.details .view-selector .details,
 #results.advanced .view-selector .advanced {
   background-color: #000;
+}
+
+@media screen and (max-width: 625px) {
+  #results .upload, #results .download {
+    float: none;
+  }
+}
+
+@media screen and (max-width: 580px) {
+  #results .view-selector-container, #results .title-container {
+    float: none;
+    text-align: left;
+  }
+
+  .upload .result h3 {
+    font-size: 28px;
+  }
+
+  #results .result .number {
+    font-size: 52px;
+    line-height: 85px;
+  }
+
+  #results .result .units {
+    font-size: 36px;
+  }
+
+  #results .controls {
+    text-align: left;
+    font-size: 28px;
+  }
+}
+
+@media screen and (max-width: 500px) {
+  #upload h2, #download h2, #results .title-container h2 {
+    font-size: 44px;
+  }
+}
+
+@media screen and (max-width: 460px) {
+  #results .upload.result h3 {
+    margin: 0px 18px;
+  }
+}
+
+@media screen and (max-width: 350px) {
+  .page {
+    margin: 10px;
+  }
+  #results .result .number {
+    font-size: 44px;
+    line-height: 75px;
+  }
+  #results .result .units {
+    font-size: 26px;
+  }
 }


### PR DESCRIPTION
This PR contains layout and style changes to make the NDT responsive within the iframe on the m-lab website.  

This update can be previewed on my [fork](http://shredtechular.github.io/m-lab.github.io/tools/ndt/).

Implementation details:
- One of the more challenging aspects of this is the usage of the iframe to incorporate the widget into the m-lab website as iframes don't automatically resize by nature (and without the use of 3rd party/addtl js the height still doesn't resize as content changes within the iframe).  To at least address the responsive widths for the iframe, I used bootstrap responsive iframe classes to wrap the iframe in the ndt markdown file.  I did slightly override the bootstrap classes to a more custom aspect ration of 54% and set a minimum height on the iframe so it doesn't go below a certain height cutting content if the device is resized to a small width.  So, this solution should prevent content from being cutoff while not having huge whitespace on desktop viewing sizes.  
- Also ensured scrollbars would appear on the iframe if content did grow outside the defined height.  For the most part this should not occur (tested in Chrome, FF, Safari, iphone 6, and several device emulators in Chrome), with the exception on the results summary screen.  The content on a couple of those tabbed screens get pretty long, and I see scrollbars that exist on the site today, so kept that functionality as is so users can scroll to see additional detailed result summary content.  The default results summary screen should not need scrollbars though on any viewing width anymore.
- The big piece was getting rid of all the fixed widths, heights, and absolute positioning that don't work well for responsive sites/apps.  The gauges now also resize responsively now based on the viewing width, so that wasn't much of an issue.
- Also centered the NDT test as I think it makes it stand out a little from the page, but if folks like it better left aligned I can change that.

- [ ] One specific note, I'd like to point out as a future task, is we should decide if the front end widget code (HTML & CSS) should live in this repo or in the NDT repo as I see it in both places now.  For example, not sure when we brought in the `ndt-test.css`, but we have that file in this repo and a `style.css` in the [NDT repo](https://github.com/m-lab/ndt/tree/master/HTML5-frontend).  Maintaining this in 2 places probably isn't ideal.  If we decide to maintain that css in the mlab website, then we may want to consider putting it into SASS instead of straight css.  I think this work is already planned, but wanted to point it out for purposes of this PR as well.


Also including some screen caps of the NDT Test at different breakpoints below to easily compare before/after:

![resp-ndt](https://cloud.githubusercontent.com/assets/2396774/14577074/4ef2d638-033d-11e6-9509-05b4d09a4deb.jpg)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/183)
<!-- Reviewable:end -->
