### PR TITLE
Bug: Fixing observatory page styling

### DIFF
--- a/_layouts/observatory.html
+++ b/_layouts/observatory.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-<div class="subpage-content full-width observatory-page">
+<div class="subpage-content container observatory-page">
 	<section id="intro-section-observatory">
 		<h1 class="section-heading">{{ page.heading }}</h1>
 

--- a/_sass/base/_base.scss
+++ b/_sass/base/_base.scss
@@ -18,7 +18,7 @@ body {
   text-rendering: optimizeLegibility;
   color: #767676;
   font-family: "Proxima Nova Regular",Arial,Helvetica,sans-serif;
-  font-size: 16px;
+  font-size: 16px!important;
   line-height: 24px;
   font-weight: normal;
 }


### PR DESCRIPTION
This PR is a fix for the issue outlined here in #182.

This layout needed the bootstrap container object which sets the gutters on the site, so will properly align the title on that page now.

Additionally, the header nav has always gotten messed up when going to that page as Observatory app styles were overriding the M-Lab website styles.  So, I also fixed this in this PR as well by setting !important on the font size for the header navs.

This PR can be previewed on my [fork](http://shredtechular.github.io/m-lab.github.io/observatory/) and including a screen cap below to easily view the changes.
<img width="1259" alt="obsv" src="https://cloud.githubusercontent.com/assets/2396774/14577452/42d36afc-0342-11e6-8061-9a3ea130cd49.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/184)
<!-- Reviewable:end -->
