### PR TITLE
Bug: Fixing NDT Test iframe scrollbar issue

### DIFF
--- a/_sass/components/_iframes.scss
+++ b/_sass/components/_iframes.scss
@@ -2,9 +2,9 @@
 
 .ndt-iframe {
   min-height: 520px;
-  padding-bottom: 54%;
+  padding-bottom: 60%;
   margin-bottom: 20px;
   -webkit-overflow-scrolling: touch;
-  overflow-y: scroll;
+  overflow-y: auto;
   border: 1px solid #CCC;
 }


### PR DESCRIPTION
This PR fixes the NDT scrollbar issue identified in #185.  The fix corrects 2 CSS settings, one for when to show scrollbars (now set to auto, instead of always "on" - which seemed to be how Ubuntu browsers were handling it) and also increased the bottom padding on the container div so hopefully scrollbars won't show up when clicking the embed button.

I was able to test this out on a Ubuntu VM, however, I wasn't able to replicate some of the issues identified in #185.  I was not able to replicate the "double" scrollbar issue on my instance, nor the active scrollbar when the embed button was clicked.  I just saw an inactive scrollbar on the iframe at all times, so I am pretty confident this is a solution that will fix the problem, but seeing as how I couldn't replicate, it would be good to test this out on my fork in the browser/OS that the issue was observed originally.  The scrollbars will show up if the height of the iframe goes outside the calculated height based on a user's viewport, so even though we are increasing the height of the iframe with the fix in this PR, there is still a chance that a user's browser settings will cause scrollbars to appear.  The scrollbars do need to at least be set to `auto` however so that user's can see the details that are on the summary screens since those are very long and scrollbars are really the only way to handle that data.

The updates can be seen on my [fork](http://shredtechular.github.io/m-lab.github.io/tools/ndt/) and below screen captures of the fix on my Ubuntu VM:

#### Before:
<img width="721" alt="screen shot 2016-04-25 at 4 12 40 pm" src="https://cloud.githubusercontent.com/assets/2396774/14797443/d9a09cc8-0b00-11e6-96a2-0db7bc7da8e0.png">

#### After:
<img width="720" alt="screen shot 2016-04-25 at 4 13 52 pm" src="https://cloud.githubusercontent.com/assets/2396774/14797452/e2bb3048-0b00-11e6-9e74-bdf4e65fe947.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/186)
<!-- Reviewable:end -->
