### PR TITLE
Blog permalink fix

### DIFF
--- a/_layouts/blog-archive.html
+++ b/_layouts/blog-archive.html
@@ -10,7 +10,7 @@ layout: default
   {% assign posts = site.posts %}
 {% endif %}
 
-<div class="container">
+<div class="container" id="blog-nav-page">
   <div class="row">
 
     {% include breadcrumbs.html %}
@@ -32,7 +32,7 @@ layout: default
 
           {% if show-post %}
 
-            <article class="blog-entry">
+            <article class="blog-entry" id="{{ post.url | prepend: site.baseurl }}">
               {% if post.content contains '<!--more-->' %}
                   {{ post.content | split:'<!--more-->' | first }}
               {% else %}

--- a/_layouts/blog-index.html
+++ b/_layouts/blog-index.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-<div class="container">
+<div class="container" id="blog-nav-page">
   <div class="row">
 
     {% include breadcrumbs.html %}
@@ -13,15 +13,15 @@ layout: default
 
           {% for post in paginator.posts %}
 
-          <article class="blog-entry">
+          <article class="blog-entry" id="{{ post.url | prepend: site.baseurl }}">
 
             {{ post.content }}
 
             <footer class="meta">
-              <small>Posted by <b class="author">{{ post.author }}</b> on <span class="published">{{ post.date | date: "%Y-%m-%d" }}</span> 
+              <small>Posted by <b class="author">{{ post.author }}</b> on <span class="published">{{ post.date | date: "%Y-%m-%d" }}</span>
 
-              {% if post.categories.size > 0 %}             
-                filed under 
+              {% if post.categories.size > 0 %}
+                filed under
                 <span class="categories">
 
                 {% for cat in post.categories %}
@@ -35,7 +35,7 @@ layout: default
             </footer>
 
           </article> <!-- .blog-entry -->
-          
+
           {% endfor %}
 
           {% if paginator.total_pages > 1 %}

--- a/js/src/controllers/enhancers/NavigationEnhancer.js
+++ b/js/src/controllers/enhancers/NavigationEnhancer.js
@@ -17,12 +17,17 @@ function(
 
       //adds anchor permalinks to any Header tag that has an id
       $(anchorElements).each(function (i, el) {
-        var $el, id;
+        var $el, id, permalink;
         $el = $(el);
         id = $el.attr('id');
         if (id) {
+          if ( $('#blog-nav-page').length ) {
+            permalink = $('.blog-entry').attr('id') + "#" + id;
+          } else {
+            permalink = "#" + id
+          }
           return $el.prepend($("<a />").addClass("anchor-link")
-            .attr("href", "#" + id).attr("data-icon", ""));
+            .attr("href", permalink).attr("data-icon", ""));
         }
       });
 
@@ -45,12 +50,12 @@ function(
       //minor event listener on mobile menu accordions to flip the arrow
       // glyphicon depending if the particular accordion is open or closed.
       $('.mobile-sub-nav').on('show.bs.collapse', function(){
-        $(this).parent().find(".glyphicon-triangle-bottom") 
-          .removeClass("glyphicon-triangle-bottom") 
+        $(this).parent().find(".glyphicon-triangle-bottom")
+          .removeClass("glyphicon-triangle-bottom")
           .addClass("glyphicon-triangle-top");
       }).on('hide.bs.collapse', function(){
         $(this).parent().find(".glyphicon-triangle-top")
-          .removeClass("glyphicon-triangle-top") 
+          .removeClass("glyphicon-triangle-top")
           .addClass("glyphicon-triangle-bottom");
       });
 


### PR DESCRIPTION
This PR addresses issue #95 where permalinks were difficult to find on the current site for blogs.   They didn't exist anywhere on the blog index page and only were able to be found on the archive pages when clicking the "read more" link.  Additionally, the anchor tag links could in theory become invalid when new blog posts are added on the blog index and blog archives pages.

This solution fixes both problems by correcting the anchor tags on the blog index and blog archive pages so that when clicked they actually go to the blog page/heading level.  This also enables a user to more easily find permalinks to specific blog entries.

The fix can be viewed on my [fork](http://shredtechular.github.io/m-lab.github.io/blog/).

The fix entails adding a couple of ids to the blog index & archive pages so that when the anchor tags are generated, the js will check to see if the user is currently on the blog index or archive pages.  It then adds the permalink URL into the anchor tag link.

I have set my editor now to remove trailing whitespace characters from all files when I save, so there are a couple of whitespace removal changes in the blog-index.html and NavigationEnhancer.js files.  Hopefully it is okay to have the whitespace removal in this PR as well since it is just a couple lines, but if that detracts from the point of this PR, I can revert them and submit a separate PR to remove the whitespace characters that I must've left in previously.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/192)
<!-- Reviewable:end -->
