### PR TITLE
Bug: H1 styling fix

### DIFF
--- a/_sass/base/_base.scss
+++ b/_sass/base/_base.scss
@@ -64,14 +64,14 @@ tr {
 }
 
 th {
-  border: 1px solid black; 
-  padding: 5px; 
-  font-weight: bold; 
+  border: 1px solid black;
+  padding: 5px;
+  font-weight: bold;
 }
 
 td {
-  border: 1px solid black; 
-  padding: 5px; 
+  border: 1px solid black;
+  padding: 5px;
 }
 
 a {
@@ -107,8 +107,8 @@ small {
 }
 
 img {
-  max-width: 100%; 
-  display:block; 
+  max-width: 100%;
+  display:block;
 }
 
 ::selection {
@@ -119,7 +119,7 @@ img {
     background: rgba(175,219,210,0.7)
 }
 
-div,span,applet,object,iframe,h1,.error-msg .error-text,h2,h3,h4,h5,h6,p,blockquote,pre,a,abbr,acronym,address,big,cite,code,del,dfn,img,ins,kbd,q,s,samp,small,strike,strong,sub,sup,tt,var,b,u,i,center,dl,dt,dd,ol,ul,li,fieldset,form,label,legend,caption,article,aside,canvas,details,embed,figure,figcaption,hgroup,menu,output,ruby,section,summary,time,mark,audio,video {
+div,span,applet,object,iframe,.error-msg .error-text,h2,h3,h4,h5,h6,p,blockquote,pre,a,abbr,acronym,address,big,cite,code,del,dfn,img,ins,kbd,q,s,samp,small,strike,strong,sub,sup,tt,var,b,u,i,center,dl,dt,dd,ol,ul,li,fieldset,form,label,legend,caption,article,aside,canvas,details,embed,figure,figcaption,hgroup,menu,output,ruby,section,summary,time,mark,audio,video {
   margin: 0;
   padding: 0;
   border: 0;


### PR DESCRIPTION
I noticed that the H1s on all data pages were not any different, styling-wise, from other text on the pages.

Currently, H1's look like this:
<img width="1217" alt="h1-before" src="https://cloud.githubusercontent.com/assets/2396774/15274980/cf4020fe-1a8d-11e6-8355-89e755653d7c.png">


I also took a look back in the [wayback archive](https://web.archive.org/web/20150912141117/http://www.measurementlab.net/blog) and this doesn't look like it was always styled that way, so looks like this was a regression at some point, probably as part of the styling conversion to SASS.  This PR remedies the H1 styling issue, as can be see on my [fork](http://shredtechular.github.io/m-lab.github.io/blog/).

After Fix Screenshot:
<img width="1217" alt="h1-after-fix" src="https://cloud.githubusercontent.com/assets/2396774/15274982/d3b8d004-1a8d-11e6-8e25-e05547ec0d41.png">

There are some trailing whitespace removal characters included with this PR, however, the real fix was just taking the h1 element out of line 122 in the file below.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/193)
<!-- Reviewable:end -->
