### PR TITLE
Bug: Mobile social share button spacing fix

### DIFF
--- a/_sass/layouts/_footer.scss
+++ b/_sass/layouts/_footer.scss
@@ -25,13 +25,17 @@
     color: #767676;
   }
 
-  .callout-ctn>li {
-      display: -moz-inline-stack;
-      display: inline-block;
-      vertical-align: middle;
-      *vertical-align: auto;
-      zoom:1;*display: inline;
-      margin-right: -1px;
+  ul.callout-ctn {
+    padding-bottom: 12px;
+
+    &>li {
+        display: -moz-inline-stack;
+        display: inline-block;
+        vertical-align: middle;
+        *vertical-align: auto;
+        zoom:1;*display: inline;
+        margin-right: -1px;
+    }
   }
 
   .footer-links {
@@ -53,7 +57,7 @@
       padding-top: 10px;
       font-size: 14px;
       line-height: 20px;
-    }   
+    }
 
     a {
       color: #d94f40;


### PR DESCRIPTION
I noticed a minor spacing issue on mobile view ports where the footer items start stacking.  The social sharing buttons were really close to the links as can be seen in the screen capture below:
<img width="391" alt="mobile-social-before-fix" src="https://cloud.githubusercontent.com/assets/2396774/15275243/1dbab810-1a94-11e6-951b-e6b76692f64a.png">

This PR fixes the issue and puts equal spacing above **and below** the social sharing buttons now, so it should look better now.  This fix can be seen on my [fork](http://shredtechular.github.io/m-lab.github.io/) and a screen capture of the fix below as well:
<img width="387" alt="mobile-social-after-fix" src="https://cloud.githubusercontent.com/assets/2396774/15275244/4463b520-1a94-11e6-9bf1-23e9800b1b36.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/194)
<!-- Reviewable:end -->
