### PR TITLE
Update HTMLProofer & Markdown Linter Gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,6 @@ gem 'github-pages', versions['github-pages']
 gem 'liquid'
 gem 'jekyll'
 gem 'jekyll-paginate'
-gem 'html-proofer', '3.0.2'
-gem 'mdl', '0.2.1'
+gem 'html-proofer', '3.0.5'
+gem 'mdl', '0.3.1'
 gem 'cf-s3-invalidator'

--- a/_linter/markdown-linter-style.rb
+++ b/_linter/markdown-linter-style.rb
@@ -3,7 +3,7 @@ all
 
 #  Rule Modifications
 #  ----------------------------------------------------------------------------
-## MD029 - tells linter to allow ordered lists that will increment by 1.  By 
+## MD029 - tells linter to allow ordered lists that will increment by 1.  By
 ## default (w/o modification) the linter doesn't accept lists structured like:
 ## 1. List item #1
 ## 2. List item #2
@@ -11,7 +11,7 @@ all
 rule 'MD029', :style => :ordered
 
 
-#  Exclude the following linter rules that conflict with the team's Markdown 
+#  Exclude the following linter rules that conflict with the team's Markdown
 #  writing preferences.
 #  ----------------------------------------------------------------------------
 ## MD013 - Line length.  Disabled unless can determine automated way to fix.
@@ -29,9 +29,6 @@ exclude_rule 'MD034'
 
 #  Excluding these rules until content can be re-worked to adhere to the rules
 #  ----------------------------------------------------------------------------
-## MD001 - Check that Header levels increment by one level at a time.
-exclude_rule 'MD001'
-
 ## MD022 - Headers should be surrounded by blank lines
 exclude_rule 'MD022'
 
@@ -46,3 +43,6 @@ exclude_rule 'MD036'
 
 ## MD038 Spaces inside code span elements
 exclude_rule 'MD038'
+
+## MD041 First line in file should be a top level header
+exclude_rule 'MD041'


### PR DESCRIPTION
We have a couple of hardcoded versions of Gems in our Gemfile, namely the Markdown Linter and the HTMLProofer gems.  This was done so builds don't automatically start failing with the release of a new gem, however, I think it is prudent to keep these gems up-to-date when possible.

This PR updates these 2 gems to the latest versions.  One advantage of updating the HTML Proofer gem is that when it is run, the latest version of the HTML Proofer eliminates a lot of "noise" that is output when it is currently run.  As you can see in Travis, the 3.0.2 version of the HTML proofer gem is outputting a lot of json debug that isn't useful to anyone and only makes builds more difficult to read - [link](https://travis-ci.org/m-lab/m-lab.github.io/builds/130397001#L322).

When upgrading to the latest Markdown linter version, there is one new rule that we needed to add to the markdown linter style because it was added in the latest version of the Markdown linter gem.

I also checked the other Markdown rules to see if any of the rules we have fixed with other updates for the site over the past month and we can now remove the MD001 rule as that is now passing.  So, we can also then close out https://github.com/m-lab/m-lab.github.io/issues/86.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/195)
<!-- Reviewable:end -->
