### PR TITLE
Removing suppression of Markdown Linter ruler # 38

### DIFF
--- a/_linter/markdown-linter-style.rb
+++ b/_linter/markdown-linter-style.rb
@@ -41,8 +41,5 @@ exclude_rule 'MD032'
 ## MD026 - Emphasis used instead of a header
 exclude_rule 'MD036'
 
-## MD038 Spaces inside code span elements
-exclude_rule 'MD038'
-
 ## MD041 First line in file should be a top level header
 exclude_rule 'MD041'

--- a/_pages/bigquery_schema.md
+++ b/_pages/bigquery_schema.md
@@ -53,7 +53,7 @@ All M-Lab data share the same data schema in BigQuery. The fields are described 
 | `connection_spec.server_af`                         |  `integer`   |  Address family of the server's IP address. (This field is **optional**. It's preferable to use `web100_log_entry.connection_spec.local_af`.) |
 | `connection_spec.server_hostname`                   |  `string`    |  Server's hostname. (This field is **optional**.) |
 | `connection_spec.server_kernel_version`             |  `string`    |  Server's kernel version. (This field is **optional**.) |
-| `connection_spec.client_ip `                        |  `string`    |  IP address of the user's client. (This field is **optional**. It's preferable to use `web100_log_entry.connection_spec.remote_ip`.) |
+| `connection_spec.client_ip`                         |  `string`    |  IP address of the user's client. (This field is **optional**. It's preferable to use `web100_log_entry.connection_spec.remote_ip`.) |
 | `connection_spec.client_af`                         |  `integer`   |  Address family of the client's IP address. (This field is **optional**.) |
 | `connection_spec.client_hostname`                   |  `string`    |  Client's hostname. (This field is **optional**.) |
 | `connection_spec.client_application`                |  `string`    |  Client application that ran the test. (This field is **optional**.) |


### PR DESCRIPTION
In doing some checking of the Markdown Linter rules that we are suppressing, rule number 38, which is currently being suppressed for spaces inside code span elements is only being flagged on one markdown file which is the `bigquery-schema.md` file.

As you can see in the change below, on line 56 of the `bigquery-schema` file, there was an extra space after `connection_spec.client_ip` and before the closing code span backtick.  I don't see any visual reason for having that space in there, so if we remove the space and re-run the markdown linter, that rule is not flagged anymore and we can remove it.

I put this change on my [fork](http://shredtechular.github.io/m-lab.github.io/data/bq/schema/), so you can compare when that space is removed, there is no visual difference with no space.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/196)
<!-- Reviewable:end -->
