### PR TITLE
Bug: Centering Homepage Video Play Button

### DIFF
--- a/_sass/components/_video.scss
+++ b/_sass/components/_video.scss
@@ -28,11 +28,9 @@
     background-size: cover;
 
     .player-control {
-      position: absolute;
-      top: 0;
-      left: 0;
-      bottom: 0;
-      margin: auto;
+      position: relative;
+      top: 50%;
+      margin: -25px auto 0px;
     }
 
     &:hover .player-control {


### PR DESCRIPTION
This PR fixes issue #161 where the play button on the homepage video was left aligned and should be centered.

Instead of absolutely positioning the play button the left, this fix relatively positions the button centered vertically and horizontally.  This fix can be viewed on my [fork](http://shredtechular.github.io/m-lab.github.io/).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/197)
<!-- Reviewable:end -->
