### PR TITLE
Bug: About Page line breaks

### DIFF
--- a/_pages/08-about.md
+++ b/_pages/08-about.md
@@ -20,11 +20,7 @@ M-Lab is a consortium of research, industry and public-interest partners dedicat
 {:.about-h2}
 ## Why Measurement Lab?
 
-Real science requires verifiable processes, and M-Lab welcomes scientific collaboration and scrutiny. This is why all of the data collected by M-Lab's global measurement platform is openly
-
-available, and all of the measurement tools hosted by M-Lab are open source. Anyone with the time and skill can review and improve the underlying methodologies and assumptions on which M-Lab's
-
-platform, tools, and data rely. Transparency and review are key to good science, and good science is key to good measurement.
+Real science requires verifiable processes, and M-Lab welcomes scientific collaboration and scrutiny. This is why all of the data collected by M-Lab's global measurement platform is openly available, and all of the measurement tools hosted by M-Lab are open source. Anyone with the time and skill can review and improve the underlying methodologies and assumptions on which M-Lab's platform, tools, and data rely. Transparency and review are key to good science, and good science is key to good measurement.
 
 {:.about-h2}
 ## An Open Platform for Researchers


### PR DESCRIPTION
This PR addresses the about page line breaks identified by @georgiamoon in issue #205 .

I think when I originally migrated the content, I had some inadvertent line breaks in the about markdown.  This PR remedies that issue and combines all of the content in the "Why Measurement Lab" section into 1 paragraph, which I think is what the intent is.

The fix can be viewed on my [fork](http://shredtechular.github.io/m-lab.github.io/about/).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/206)
<!-- Reviewable:end -->
