### PR TITLE
Remove contribute and wiki from header, replace with tag line

### DIFF
--- a/_data/header-footer-content.yml
+++ b/_data/header-footer-content.yml
@@ -5,7 +5,7 @@ header:
   -
     link: "/about/"
     h2: "Measurement Lab is a partnership between New America's Open Technology Institute, Google Open Source Research, Princeton University's PlanetLab, and other supporting partners."
-    h3: "Learn more about M-Lab."
+    h3: "Learn more about M-Lab"
     class: "assist-cta"
   category:
     -

--- a/_data/header-footer-content.yml
+++ b/_data/header-footer-content.yml
@@ -3,7 +3,7 @@ header:
   logo-title: "M-Lab"
   ctas:
   -
-    h2: "A partnership between New America\'s <a href='https://newamerica.org/oti'>Open Technology Institute</a>, Google Open Source Research, <a href='https://planet-lab.org'>Princeton University\'s PlanetLab</a>, and other supporting partners. <a href='/about'>Learn more.</a>"
+    h2: "A partnership between New America's <a href='https://newamerica.org/oti'>Open Technology Institute</a>, Google Open Source Research, <a href='https://planet-lab.org'>Princeton University\'s PlanetLab</a>, and other supporting partners. <a href='/about'>Learn more.</a>"
     class: "assist-cta"
   category:
     -

--- a/_data/header-footer-content.yml
+++ b/_data/header-footer-content.yml
@@ -3,7 +3,7 @@ header:
   logo-title: "M-Lab"
   ctas:
   -
-    h2: "A partnership between New America's <a href='https://newamerica.org/oti'>Open Technology Institute</a>, Google Open Source Research, <a href='https://planet-lab.org'>Princeton University\'s PlanetLab</a>, and other supporting partners. <a href='/about'>Learn more.</a>"
+    h2: "A partnership between New America's <a href=\"https://newamerica.org/oti\">Open Technology Institute</a>, Google Open Source Research, <a href=\"https://planet-lab.org\">Princeton University's PlanetLab</a>, and other supporting partners. <a href=\"/about\">Learn more.</a>"
     class: "assist-cta"
   category:
     -

--- a/_data/header-footer-content.yml
+++ b/_data/header-footer-content.yml
@@ -3,8 +3,8 @@ header:
   logo-title: "M-Lab"
   ctas:
   -
-    link: "/who/"
-    h2: "A partnership between New America's Open Technology Institute, Google Open Source Research, Princeton University's PlanetLab, and other supporting partners. "
+    link: "/about/"
+    h2: "A partnership between New America's <a href='https://newamerica.org/oti'>Open Technology Institute</a>, Google Open Source Research, Princeton University's PlanetLab, and other supporting partners. "
     h3: "Learn more"
     class: "assist-cta"
   category:

--- a/_data/header-footer-content.yml
+++ b/_data/header-footer-content.yml
@@ -3,9 +3,7 @@ header:
   logo-title: "M-Lab"
   ctas:
   -
-    link: "/about/"
-    h2: "A partnership between New America\'s <a href='https://newamerica.org/oti'>Open Technology Institute</a>, Google Open Source Research, <a href='https://planet-lab.org'>Princeton University\'s PlanetLab</a>, and other supporting partners. "
-    h3: "Learn more"
+    h2: "A partnership between New America\'s <a href='https://newamerica.org/oti'>Open Technology Institute</a>, Google Open Source Research, <a href='https://planet-lab.org'>Princeton University\'s PlanetLab</a>, and other supporting partners. <a href='/about'>Learn more.</a>"
     class: "assist-cta"
   category:
     -

--- a/_data/header-footer-content.yml
+++ b/_data/header-footer-content.yml
@@ -3,15 +3,10 @@ header:
   logo-title: "M-Lab"
   ctas:
   -
-    link: "/contribute/"
-    h2: "Help us grow and improve"
-    h3: "Contribute to M-Lab"
+    link: "/who/"
+    h2: "A partnership between New America's Open Technology Institute, Google Open Source Research, Princeton University's PlanetLab, and other supporting partners. "
+    h3: "Learn more about M-Lab"
     class: "assist-cta"
-  -
-    link: "https://github.com/m-lab/mlab-wikis"
-    h2: "Read about our projects"
-    h3: "Research Wiki"
-    class: "learn-cta"
   category:
     -
       title: "about"

--- a/_data/header-footer-content.yml
+++ b/_data/header-footer-content.yml
@@ -5,7 +5,7 @@ header:
   -
     link: "/who/"
     h2: "A partnership between New America's Open Technology Institute, Google Open Source Research, Princeton University's PlanetLab, and other supporting partners. "
-    h3: "Learn more about M-Lab"
+    h3: "Learn more"
     class: "assist-cta"
   category:
     -

--- a/_data/header-footer-content.yml
+++ b/_data/header-footer-content.yml
@@ -3,7 +3,9 @@ header:
   logo-title: "M-Lab"
   ctas:
   -
-    h2: "A partnership between New America's <a href=\"https://newamerica.org/oti\">Open Technology Institute</a>, Google Open Source Research, <a href=\"https://planet-lab.org\">Princeton University's PlanetLab</a>, and other supporting partners. <a href=\"/about\">Learn more.</a>"
+    link: "/about/"
+    h2: "A partnership between New America's <a href=\"https://newamerica.org/oti\">Open Technology Institute</a>, Google Open Source Research, <a href=\"https://planet-lab.org\">Princeton University's PlanetLab</a>, and other supporting partners."
+    h3: "Learn more."
     class: "assist-cta"
   category:
     -

--- a/_data/header-footer-content.yml
+++ b/_data/header-footer-content.yml
@@ -4,7 +4,7 @@ header:
   ctas:
   -
     link: "/about/"
-    h2: "A partnership between New America's <a href=\"https://newamerica.org/oti\">Open Technology Institute</a>, Google Open Source Research, <a href=\"https://planet-lab.org\">Princeton University's PlanetLab</a>, and other supporting partners."
+    h2: "A partnership between New America&#39;s <a href='https://newamerica.org/oti'>Open Technology Institute</a>, Google Open Source Research, <a href='https://planet-lab.org'>Princeton University&#39;s PlanetLab</a>, and other supporting partners."
     h3: "Learn more."
     class: "assist-cta"
   category:

--- a/_data/header-footer-content.yml
+++ b/_data/header-footer-content.yml
@@ -4,7 +4,7 @@ header:
   ctas:
   -
     link: "/about/"
-    h2: "A partnership between New America's <a href='https://newamerica.org/oti'>Open Technology Institute</a>, Google Open Source Research, Princeton University's PlanetLab, and other supporting partners. "
+    h2: "A partnership between New America\'s <a href='https://newamerica.org/oti'>Open Technology Institute</a>, Google Open Source Research, <a href='https://planet-lab.org'>Princeton University\'s PlanetLab</a>, and other supporting partners. "
     h3: "Learn more"
     class: "assist-cta"
   category:

--- a/_data/header-footer-content.yml
+++ b/_data/header-footer-content.yml
@@ -4,7 +4,7 @@ header:
   ctas:
   -
     link: "/about/"
-    h2: "A partnership between New America&#39;s <a href='https://newamerica.org/oti'>Open Technology Institute</a>, Google Open Source Research, <a href='https://planet-lab.org'>Princeton University&#39;s PlanetLab</a>, and other supporting partners."
+    h2: "Measurement Lab is a partnership between New America&#39;s <a href='https://newamerica.org/oti'>Open Technology Institute</a>, Google Open Source Research, <a href='https://planet-lab.org'>Princeton University&#39;s PlanetLab</a>, and other supporting partners."
     h3: "Learn more."
     class: "assist-cta"
   category:

--- a/_data/header-footer-content.yml
+++ b/_data/header-footer-content.yml
@@ -4,8 +4,8 @@ header:
   ctas:
   -
     link: "/about/"
-    h2: "Measurement Lab is a partnership between New America&#39;s <a href='https://newamerica.org/oti'>Open Technology Institute</a>, Google Open Source Research, <a href='https://planet-lab.org'>Princeton University&#39;s PlanetLab</a>, and other supporting partners."
-    h3: "Learn more."
+    h2: "Measurement Lab is a partnership between New America's Open Technology Institute, Google Open Source Research, Princeton University's PlanetLab, and other supporting partners."
+    h3: "Learn more about M-Lab."
     class: "assist-cta"
   category:
     -

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -32,7 +32,7 @@
 
     {% for item in header.ctas %}
       <div class="col-xs-7 col-sm-7" id="{{ item.class }}">
-        <a href="{% if item.link | slice: 0 = "/" %}{{ item.link | prepend: site.baseurl }}{% else %}{{ item.link }}{% endif }" class="header-cta {{ item.class }}">
+        <a href="{% if item.link | slice: 0 = "/" %}{{ item.link | prepend: site.baseurl }}{% else %}{{ item.link }}{% endif %}" class="header-cta {{ item.class }}">
           <span class="pull-right">
             <h2>{{ item.h2 }}</h2>
             <h3>{{ item.h3 }}</h3>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -31,7 +31,7 @@
       </div>
 
     {% for item in header.ctas %}
-      <div class="col-xs-5 col-sm-5 col-md-4" id="{{ item.class }}">
+      <div class="col-xs-5 col-sm-5" id="{{ item.class }}">
         <a href="{% if item.link | slice: 0 = "/" %}{{ item.link | prepend: site.baseurl }}{% else %}{{ item.link }}{% endif %}" class="header-cta {{ item.class }}">
           <span class="pull-right">
             <h2>{{ item.h2 }}</h2>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -31,7 +31,7 @@
       </div>
 
     {% for item in header.ctas %}
-      <div class="col-xs-7 col-sm-7" id="{{ item.class }}">
+      <div class="col-xs-8 col-sm-8" id="{{ item.class }}">
         <a href="{% if item.link | slice: 0 = "/" %}{{ item.link | prepend: site.baseurl }}{% else %}{{ item.link }}{% endif %}" class="header-cta {{ item.class }}">
           <span class="pull-right">
             <h2>{{ item.h2 }}</h2>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -31,8 +31,8 @@
       </div>
 
     {% for item in header.ctas %}
-      <div class="col-xs-5 col-sm-5" id="{{ item.class }}">
-        <a href="{% if item.link | slice: 0 = "/" %}{{ item.link | prepend: site.baseurl }}{% else %}{{ item.link }}{% endif %}" class="header-cta {{ item.class }}">
+      <div class="col-xs-7 col-sm-7" id="{{ item.class }}">
+        <a href="{% if item.link | slice: 0 = "/" %}{{ item.link | prepend: site.baseurl }}{% else %}{{ item.link }}{% endif }" class="header-cta {{ item.class }}">
           <span class="pull-right">
             <h2>{{ item.h2 }}</h2>
             <h3>{{ item.h3 }}</h3>

--- a/_sass/layouts/_header.scss
+++ b/_sass/layouts/_header.scss
@@ -30,10 +30,6 @@ header.header-section {
     }
 
     div.assist-cta, div.learn-cta {
-      background: url('../images/sprites/globalSprite-1x.png') no-repeat;
-      float: right;
-      position: relative;
-      top: 5px;
     }
 
     div.assist-cta {


### PR DESCRIPTION
This PR addresses issue #164 by removing the Contribute and Wiki links and images in the header, and per our discussions in staff meeting, replaces it with a tagline linking to the /who/ page.

This PR can be previewed on my fork:
https://critzo.github.io/m-lab.github.io/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/212)
<!-- Reviewable:end -->
