### PR TITLE
Update traffic microbursts blog post & related documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Current Build Status is: [![Build Status](https://secure.travis-ci.org/m-lab/m-l
 
 ### Pre-commit Hook
 
-Developers should also install the pre-commit hook that comes packaged with this repository that will alert about any trailing whitespaces to minimize git diff noise.  In order to install the pre-commit hook, run the following command to create a symbolic link: `rm -rf .git/hooks/ && ln -s -f ../_hooks .git/hooks/`.
+Developers should also install the pre-commit hook that comes packaged with this repository that will alert about any trailing whitespaces to minimize git diff noise.  In order to install the pre-commit hook, run the following command to create a symbolic link: `rm -rf .git/hooks/ && ln -s -f ../_hooks .git/hooks/`
 
 ### HTML Compression
 

--- a/_pages/bigquery_schema.md
+++ b/_pages/bigquery_schema.md
@@ -122,6 +122,63 @@ The following fields are deprecated and no longer have meaning in the data set.
 | `string`      |  `Ip_Address`            |
 | `bool`        |  `TruthValue`            |
 
+### Blacklist Flags Field 
+
+An additional field called ```blacklist_flags``` was added to all tables in response to a "switch discard issue", which identified that some historical tests were affected by traffic microbursts. See our [blog post]({{ site.baseurl }}/blog/traffic-microbursts-and-their-effect-on-internet-measurement) for complete details. 
+
+The ```blacklist_flags``` field is used to mark test results if they meet specific parameters that qualify them for inclusion or exclusion in queries or research analyses. This field was created to mark tests affected by the "switch discard issue" identified in 2015-2016, but M-Lab may use the field for other use cases in the future. 
+
+Currently, the following values are present in our data in this field:
+
+| Field Name | Value | Description |
+| ---------- | ----- | ----------- |
+| `blacklist_flags` | `0` | unaffected tests |
+| | `1` | affected tests |
+| | `2` | unknown cases |
+
+M-Lab recommends that you update your queries to include ```AND blacklist_flags == 0``` to limit results to unaffected test results. Sample queries for reference are listed below.
+
+``` 
+# Sample Fast Table query limiting to unaffected tests
+
+SELECT
+  num_tests,
+FROM
+  (
+    SELECT
+      COUNT(*) num_tests,
+    FROM
+      plx.google:m_lab.ndt.all
+    WHERE
+      web100_log_entry.log_time >= PARSE_UTC_USEC('2009-08-01 00:00:00') / POW(10, 6)
+      AND web100_log_entry.log_time < PARSE_UTC_USEC('2009-09-01 00:00:00') / POW(10, 6)
+      AND blacklist_flags == 0
+  )
+GROUP BY
+  num_tests
+```
+
+``` 
+# Sample Legacy Monthly Table query limiting to unaffected tests
+
+SELECT
+  num_tests,
+FROM
+  (
+    SELECT
+      COUNT(*) num_tests,
+    FROM
+      plx.google:m_lab.2009_08.all
+    WHERE
+      web100_log_entry.log_time >= PARSE_UTC_USEC('2009-08-01 00:00:00') / POW(10, 6)
+      AND web100_log_entry.log_time < PARSE_UTC_USEC('2009-09-01 00:00:00') / POW(10, 6)
+      AND blacklist_flags == 0
+      AND web100_log_entry.is_last_entry == 1
+  )
+GROUP BY
+  num_tests
+```
+
 ## Query Examples
 
 See [BigQuery Examples]({{ site.baseurl }}/data/bq/examples) for examples of queries against this schema.

--- a/_pages/bigquery_schema.md
+++ b/_pages/bigquery_schema.md
@@ -124,17 +124,17 @@ The following fields are deprecated and no longer have meaning in the data set.
 
 ### Blacklist Flags Field
 
-An additional field called ```blacklist_flags``` was added to all tables in response to a "switch discard issue", which identified that some historical tests were affected by traffic microbursts. See our [blog post]({{ site.baseurl }}/blog/traffic-microbursts-and-their-effect-on-internet-measurement) for complete details.
+An additional field called ```blacklist_flags``` was added to all tables in response to a switch discard issue, an episode of degraded performance. See our [blog post]({{ site.baseurl }}/blog/traffic-microbursts-and-their-effect-on-internet-measurement) for complete details.
 
-The ```blacklist_flags``` field is used to mark test results if they meet specific parameters that qualify them for inclusion or exclusion in queries or research analyses. This field was created to mark tests affected by the "switch discard issue" identified in 2015-2016, but M-Lab may use the field for other use cases in the future.
+The ```blacklist_flags``` field is used to mark test results that could be impacted by site configuration issues, or otherwise communicate potentially relevant information about the state of the platform at the time of the test. This field was created to mark tests affected by the "switch discard issue" identified in 2015-2016, but M-Lab may use the field for other use cases in the future.
 
 Currently, the following values are present in our data in this field:
 
 | Field Name | Value | Description |
 | ---------- | ----- | ----------- |
 | `blacklist_flags` | `0` | unaffected tests |
-| | `1` | affected tests |
-| | `2` | unknown cases |
+| | `1` | tests affected by switch discards |
+| | `2` | tests not shown to be unaffected by switch discards |
 
 M-Lab recommends that you update your queries to include ```AND blacklist_flags == 0``` to limit results to unaffected test results. Sample queries for reference are listed below.
 

--- a/_pages/bigquery_schema.md
+++ b/_pages/bigquery_schema.md
@@ -179,6 +179,6 @@ GROUP BY
   num_tests
 ```
 
-## Query Examples
+## BigQuery Examples
 
 See [BigQuery Examples]({{ site.baseurl }}/data/bq/examples) for examples of queries against this schema.

--- a/_pages/bigquery_schema.md
+++ b/_pages/bigquery_schema.md
@@ -122,11 +122,11 @@ The following fields are deprecated and no longer have meaning in the data set.
 | `string`      |  `Ip_Address`            |
 | `bool`        |  `TruthValue`            |
 
-### Blacklist Flags Field 
+### Blacklist Flags Field
 
-An additional field called ```blacklist_flags``` was added to all tables in response to a "switch discard issue", which identified that some historical tests were affected by traffic microbursts. See our [blog post]({{ site.baseurl }}/blog/traffic-microbursts-and-their-effect-on-internet-measurement) for complete details. 
+An additional field called ```blacklist_flags``` was added to all tables in response to a "switch discard issue", which identified that some historical tests were affected by traffic microbursts. See our [blog post]({{ site.baseurl }}/blog/traffic-microbursts-and-their-effect-on-internet-measurement) for complete details.
 
-The ```blacklist_flags``` field is used to mark test results if they meet specific parameters that qualify them for inclusion or exclusion in queries or research analyses. This field was created to mark tests affected by the "switch discard issue" identified in 2015-2016, but M-Lab may use the field for other use cases in the future. 
+The ```blacklist_flags``` field is used to mark test results if they meet specific parameters that qualify them for inclusion or exclusion in queries or research analyses. This field was created to mark tests affected by the "switch discard issue" identified in 2015-2016, but M-Lab may use the field for other use cases in the future.
 
 Currently, the following values are present in our data in this field:
 
@@ -138,7 +138,7 @@ Currently, the following values are present in our data in this field:
 
 M-Lab recommends that you update your queries to include ```AND blacklist_flags == 0``` to limit results to unaffected test results. Sample queries for reference are listed below.
 
-``` 
+~~~sql
 # Sample Fast Table query limiting to unaffected tests
 
 SELECT
@@ -156,9 +156,9 @@ FROM
   )
 GROUP BY
   num_tests
-```
+~~~
 
-``` 
+~~~sql
 # Sample Legacy Monthly Table query limiting to unaffected tests
 
 SELECT
@@ -177,7 +177,7 @@ FROM
   )
 GROUP BY
   num_tests
-```
+~~~
 
 ## BigQuery Examples
 

--- a/_posts/blog/2016-05-25-traffic-microbursts-and-their-effect-on-internet-measurement.md
+++ b/_posts/blog/2016-05-25-traffic-microbursts-and-their-effect-on-internet-measurement.md
@@ -27,3 +27,7 @@ This document does the following:
 A full accounting can be found in our incident report available here:
 
 [Traffic Microbursts and their Effect on Internet Measurement (PDF)]({{ site.baseurl }}/publications/SwitchDiscardNotice-Final-20160525.pdf){:.download-link .paper-download target="_blank"}
+
+## Update, November 2016
+
+Following the remediation methods described above, M-Lab NDT and Sidestream data are now marked in BigQuery. Our [data documentation]({{ site.baseurl }}/data) will be updated shortly, but in summary, a new field was added to our schema called "blacklist_flags", and provides a means of easily querying for affected or unaffected tests mentioned in the above incident. No future problems are anticipated, but the new field has been designed to signal any possible future events worth considering in our data. 

--- a/_posts/blog/2016-05-25-traffic-microbursts-and-their-effect-on-internet-measurement.md
+++ b/_posts/blog/2016-05-25-traffic-microbursts-and-their-effect-on-internet-measurement.md
@@ -30,4 +30,4 @@ A full accounting can be found in our incident report available here:
 
 ## Update, November 2016
 
-Following the remediation methods described above, M-Lab NDT and Sidestream data are now marked in BigQuery. Our [data documentation]({{ site.baseurl }}/data) will be updated shortly, but in summary, a new field was added to our schema called "blacklist_flags", and provides a means of easily querying for affected or unaffected tests mentioned in the above incident. No future problems are anticipated, but the new field has been designed to signal any possible future events worth considering in our data. 
+Following the remediation methods described above, M-Lab NDT and Sidestream data are now marked in BigQuery. Our [data documentation]({{ site.baseurl }}/data) will be updated shortly, but in summary, a new field was added to our schema called "blacklist_flags", and provides a means of easily querying for affected or unaffected tests mentioned in the above incident. No future problems are anticipated, but the new field has been designed to signal any possible future events worth considering in our data.

--- a/hooks
+++ b/hooks
@@ -1,0 +1,1 @@
+.git/hooks/


### PR DESCRIPTION
This PR adds an update to the traffic microbursts blog post and the schema page to add details about the blacklist_flags field, which has now been applied to the data tables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/220)
<!-- Reviewable:end -->
