### PR TITLE
Pull data from mlab-observatory-staging bucket instead of mlab-observatory bucket.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,6 +26,7 @@ exclude:
   - README.md
   - Gemfile
   - Gemfile.lock
+  - vendor
 
 # Markdown settings
 markdown: kramdown

--- a/js/observatory/paths.js
+++ b/js/observatory/paths.js
@@ -4,7 +4,7 @@ Specifies commonly used data paths within Observatory.
 */
 (function() {
   var exports = new EventEmitter();
-  exports.dataRoot = 'https://storage.googleapis.com/mlab-observatory/';
+  exports.dataRoot = 'https://storage.googleapis.com/mlab-observatory-staging/';
 
   if (!window.mlabOpenInternet) {
     window.mlabOpenInternet = {};


### PR DESCRIPTION
Someone wrote in to support@ stating that Observatory was broken on the M-Lab site. It turns out that Cross-Origin checks were failing to URLs like:

https://storage.googleapis.com/mlab-observatory/metadata/<somefile>

Upon inspection is seems as if somehow the mlab-observatory GCS bucket disappeared.  Nobody knows how or when. Since Observatory is being replaced shortly be viz.measurementlab.net, this PR is a quick workaround to get Observatory back up and running by pointing the site to the bucket `mlab-observatory-staging` which does still exist, and has all the files we need.  We don't know for sure whether the files in this bucket are identical to the ones from the missing `mlab-observatory` bucket, but they are good enough to get the Observatory working again with no errors at least.

I also found that building the site consistently failed on some files in the `vendor/` directory. `vendor/` is untracked in this repository and I don't think we need to attempting to build anything in it when generating the site, so I added it to the exclude list so that the site would build properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/227)
<!-- Reviewable:end -->
