### PR TITLE
added data pipeline blog post

### DIFF
--- a/_pages/categories/pipeline.md
+++ b/_pages/categories/pipeline.md
@@ -1,0 +1,8 @@
+---
+layout: blog-archive
+title: Pipeline
+permalink: /blog/category/pipeline/
+archive-name: pipeline
+archive-type: Category
+breadcrumb: blog
+---

--- a/_pages/dates/2017-05.md
+++ b/_pages/dates/2017-05.md
@@ -1,0 +1,8 @@
+---
+layout: blog-archive
+title: "May 2017"
+permalink: /blog/2017/05/
+archive-name: May 2017
+archive-type: Monthly
+breadcrumb: blog
+---

--- a/_posts/blog/2017-05-02-transitioning-data-pipeline.md
+++ b/_posts/blog/2017-05-02-transitioning-data-pipeline.md
@@ -1,0 +1,17 @@
+---
+layout: blog
+title: "Transitioning to a New Backend Pipeline and Data Availability"
+author: "Richard Roberto"
+breadcrumb: blog
+categories:
+  - data
+  - pipeline
+---
+
+# Transitioning to a New Backend Pipeline and Data Availability
+
+M-Lab data is collected from distributed experiments hosted on servers all over the world, processed in a pipeline, and published for free in both raw and parsed (structured) formats. The back end processing component for this has served us well for many years, but it's been showing its age recently. As M-Lab collects an increasing amount of data thanks to new partnerships, we have been concerned that it will not be as reliable.<!--more-->
+
+To address this, we've been working on replacing the aging back-end system with a new cloud based pipeline that will be able to process much higher data volumes with greater transparency and lower latency. As part of the switch from the old pipeline to the new one, we will have a period of time where data will not be published in a regular and timely interval. All data will be published, but we anticipate a period during the transition where data from April 21 to the end of May will not be published until June 1st. Data published before that time will remain available, and experiments will still function as expected despite the delay in data publication. Experiments that collect data through their own independent pipelines will not be affected. We expect that when this transition is complete, experiment data will be published in both raw and parsed formats with no more than 1 day of latency.
+
+We will continue to update you on additional developments on the transition and look forward to posting more exciting information about our new cloud based pipeline.

--- a/_posts/blog/2017-05-02-transitioning-data-pipeline.md
+++ b/_posts/blog/2017-05-02-transitioning-data-pipeline.md
@@ -1,7 +1,7 @@
 ---
 layout: blog
 title: "Transitioning to a New Backend Pipeline and Data Availability"
-author: "Richard Roberto"
+author: "Chris Ritzo"
 breadcrumb: blog
 categories:
   - bigquery

--- a/_posts/blog/2017-05-02-transitioning-data-pipeline.md
+++ b/_posts/blog/2017-05-02-transitioning-data-pipeline.md
@@ -4,8 +4,13 @@ title: "Transitioning to a New Backend Pipeline and Data Availability"
 author: "Richard Roberto"
 breadcrumb: blog
 categories:
+  - bigquery
   - data
+  - data-analysis
+  - gcs
+  - performance
   - pipeline
+  - research
 ---
 
 # Transitioning to a New Backend Pipeline and Data Availability


### PR DESCRIPTION
This commit adds the blog post about the updating of the data pipeline and associated month/tag pages where required.

This content can be previewed on my fork:
https://critzo.github.io/m-lab.github.io/blog/transitioning-data-pipeline/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/255)
<!-- Reviewable:end -->
