### PR TITLE
adds back a carousel item for the interconnection report per #261

### DIFF
--- a/_pages/home.md
+++ b/_pages/home.md
@@ -28,6 +28,12 @@ carousel-items:
     caption: "Test your connection speed and receive a sophisticated diagnosis of problems limiting performance."
     link: "/tools/ndt/"
     link-text: "Go to NDT (Network Diagnostic Test)"
+  - image: "isp.jpg"
+    alt: "This research reveals that consumer access and performance are directly affected by the business relationships between interconnecting Internet Service Providers (ISPs)."
+    heading: "ISP Interconnection and its Impact on Consumer Internet Performance"
+    caption: "Read the M-Lab research team's report on ISP Interconnection pointing to consumer harm."
+    link: "/publications/isp-interconnection-impact.pdf"
+    link-text: "Read the report!"
 ---
 
 **M-Lab provides the largest collection of open Internet performance data on the planet.** As a consortium of research, industry, and public-interest partners, M-Lab is dedicated to providing an ecosystem for the open, verifiable measurement of global network performance. Real science requires verifiable processes, and M-Lab welcomes scientific collaboration and scrutiny. This is why all of the data collected by M-Lab’s global measurement platform are made _openly available_, and all of the measurement tools hosted by M-Lab are _open source_. Anyone with time and skill can review and improve the underlying methodologies and assumptions on which M-Lab’s platform, tools, and data rely. Transparency and review are key to good science, and good science is key to good measurement.


### PR DESCRIPTION
This commit adds a front page promo item for the 2014 interconnection report, which had been removed in a prior update.

The content change can be previewed here: https://critzo.github.io/m-lab.github.io/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/262)
<!-- Reviewable:end -->
