### PR TITLE
Update privacy.md

### DIFF
--- a/_pages/privacy.md
+++ b/_pages/privacy.md
@@ -66,7 +66,7 @@ M-Lab collects and publishes the:
 * public-facing Internet Protocol (IP) address of the client that conducted the measurement; and
 * the date and time of the test.
 
-The user's IP address and time of the test are necessary to understand and describe experiment results.
+The IP address and time of the test are necessary to understand and describe experiment results.
 
 _c. Metadata_
 


### PR DESCRIPTION
We said "public facing IP address of the client" one place, and "user's IP address" another. The first is more correct, so I have left it in and removed the "user's" modifier on the later use of "IP address".

I have no idea why that last line is shown as modified. I suspect it lacks a trailing newline, and the webform has helpfully added one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/302)
<!-- Reviewable:end -->
