### PR TITLE
alphebetized test list and separated into active/non active tests

### DIFF
--- a/_pages/04-data.md
+++ b/_pages/04-data.md
@@ -24,7 +24,7 @@ There is typically at least a 24-hour delay between data collection and data pub
 
 ### Active Tests
 
-* [mlab-collectd](https://console.developers.google.com/storage/browser/m-lab/utilization/){:target="_blank"}
+* [M-Lab Collectd](https://console.developers.google.com/storage/browser/m-lab/utilization/){:target="_blank"}
   * mlab-collectd is a monitoring tool for M-Lab slices, which collects resource utilization information about all M-Lab servers.
   * More information is available on [Github](https://github.com/m-lab/collectd-mlab){:target="_blank"}.
 * [Neubot](https://console.developers.google.com/storage/browser/m-lab/neubot/){:target="_blank"}

--- a/_pages/04-data.md
+++ b/_pages/04-data.md
@@ -22,15 +22,17 @@ There is typically at least a 24-hour delay between data collection and data pub
 
 ## Links to Raw Data for M-Lab Tests
 
-* [Glasnost](https://console.developers.google.com/storage/browser/m-lab/glasnost/){:target="_blank"}
-  * Glasnost detects prioritization or censorship of network traffic.
-  * More information is available at [MPI SWS](http://broadband.mpi-sws.org/transparency/bttest-mlab.php){:target="_blank"} and [Github](https://github.com/marcelscode/glasnost){:target="_blank"}.
-* [NDT](https://console.developers.google.com/storage/browser/m-lab/ndt/){:target="_blank"}
-  * Network Diagnostic Tool (NDT) measures characteristics of a TCP connection under heavy load.
-  * More information is available at [Internet2](http://software.internet2.edu/ndt/){:target="_blank"} and [Github](https://github.com/ndt-project/ndt){:target="_blank"}.
+### Active Tests
+
+* [mlab-collectd](https://console.developers.google.com/storage/browser/m-lab/utilization/){:target="_blank"}
+  * mlab-collectd is a monitoring tool for M-Lab slices, which collects resource utilization information about all M-Lab servers.
+  * More information is available on [Github](https://github.com/m-lab/collectd-mlab){:target="_blank"}.
 * [Neubot](https://console.developers.google.com/storage/browser/m-lab/neubot/){:target="_blank"}
   * Neubot measures the Internet in order to gather data useful to study broadband performance, network neutrality, and Internet censorship.
   * More information is available at [Nexa Center](https://neubot.nexacenter.org/){:target="_blank"} and [Github](https://github.com/neubot){:target="_blank"}.
+* [NDT](https://console.developers.google.com/storage/browser/m-lab/ndt/){:target="_blank"}
+  * Network Diagnostic Tool (NDT) measures characteristics of a TCP connection under heavy load.
+  * More information is available at [Internet2](http://software.internet2.edu/ndt/){:target="_blank"} and [Github](https://github.com/ndt-project/ndt){:target="_blank"}.
 * [NPAD](https://console.developers.google.com/storage/browser/m-lab/npad/){:target="_blank"}
   * Network Path and Application Diagnosis (NPAD) diagnoses issues in a network path that can degrade network performance.
   * More information is available at [UCAR](http://www.ucar.edu/npad/){:target="_blank"} and [Github](https://github.com/npad/npad){:target="_blank"}.
@@ -40,6 +42,15 @@ There is typically at least a 24-hour delay between data collection and data pub
 * [Paris Traceroute](https://console.developers.google.com/storage/browser/m-lab/paris-traceroute/){:target="_blank"}
   * Paris Traceroute maps network topology between two points on the Internet.
   * More information is available at [Paris Traceroute](http://www.paris-traceroute.net/){:target="_blank"}
+* [SideStream](https://console.developers.google.com/storage/browser/m-lab/sidestream/){:target="_blank"}
+  * SideStream collects TCP state information about completed TCP connections on a system.
+  * More information is available on [Github](https://github.com/npad/sidestream){:target="_blank"}.
+
+### Inactive Tests
+
+* [Glasnost](https://console.developers.google.com/storage/browser/m-lab/glasnost/){:target="_blank"} (**deprecated**)
+  * Glasnost detects prioritization or censorship of network traffic.
+  * More information is available at [MPI SWS](http://broadband.mpi-sws.org/transparency/bttest-mlab.php){:target="_blank"} and [Github](https://github.com/marcelscode/glasnost){:target="_blank"}.
 * [pathload2](https://console.developers.google.com/storage/browser/m-lab/pathload2/){:target="_blank"} (**deprecated**)
   * **M-Lab no longer supports this tool, but its archived data are available on GCS. For similar measurements with a current and supported tool, see NDT.**
   * Pathload2 measures the available bandwidth of an Internet connection.
@@ -48,12 +59,6 @@ There is typically at least a 24-hour delay between data collection and data pub
   * **M-Lab no longer supports this tool, but its archived data are available on GCS.**
   * ShaperProbe detects prioritization of network traffic.
   * More information is available at [ShaperProbe](http://netinfer.net/diffprobe/shaperprobe.html){:target="_blank"}.
-* [SideStream](https://console.developers.google.com/storage/browser/m-lab/sidestream/){:target="_blank"}
-  * SideStream collects TCP state information about completed TCP connections on a system.
-  * More information is available on [Github](https://github.com/npad/sidestream){:target="_blank"}.
-* [mlab-collectd](https://console.developers.google.com/storage/browser/m-lab/utilization/){:target="_blank"}
-  * mlab-collectd is a monitoring tool for M-Lab slices, which collects resource utilization information about all M-Lab servers.
-  * More information is available on [Github](https://github.com/m-lab/collectd-mlab){:target="_blank"}.
 
 ## Data License and Citing M-Lab Data
 


### PR DESCRIPTION
This PR makes some updates to the links to tests' data on the /data page. Alphabetizes them and separates them into active/inactive test sections.

@georgiamoon PTAL when you have a moment? https://critzo.github.io/m-lab.github.io/data/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/318)
<!-- Reviewable:end -->
