### PR TITLE
Add tools to data/tools page

### DIFF
--- a/_pages/datatools.md
+++ b/_pages/datatools.md
@@ -13,9 +13,10 @@ This page describes software tools that can be used to run M-Lab tests and acces
 
 Supported tools are those which have been developed and are maintained by the core M-Lab staff.
 
-* [Telescope](https://github.com/m-lab/telescope){:target="_blank"} - _Telescope_ is a Python framework designed to extract raw measurements from M-Lab to allow the easy production of research.
 * [M-Lab Measure Chrome App](https://chrome.google.com/webstore/detail/m-lab-measure/leijmacehibmiomcnpaolboihcdepokh?utm_source=chrome-app-launcher-info-dialog){:target="_blank"} - _M-Lab Measure_ is an extension for the Google Chrome browser that lets users schedule NDT to run at regular intervals to track the performance of and Internet connection over time.
-
+* [MeasurementKit](https://measurement-kit.github.io/){:target="_blank"} _MeasurementKit_ is a C++ library supported by M-Lab, supporting integrations outside of the browser. Supported tests include NDT, Neubot, and the OONI test suite.
+* [Murakami](https://github.com/m-lab/murakami) - Murakami is a tool for creating an automatic M-Lab testing platform with as little effort as possible. Once running, Murakami runs an NDT test roughly every twelve hours and stores the results for your analysis.
+* [Telescope](https://github.com/m-lab/telescope){:target="_blank"} - _Telescope_ is a Python framework designed to extract raw measurements from M-Lab to allow the easy production of research.
 ## Community
 
 Community tools are developed by other organizations or individuals, but which leverage the M-Lab platform and data. If you are interested in listing your community tool here, please [contact us](mailto: support@measurementlab.net).

--- a/_pages/datatools.md
+++ b/_pages/datatools.md
@@ -17,6 +17,7 @@ Supported tools are those which have been developed and are maintained by the co
 * [MeasurementKit](https://measurement-kit.github.io/){:target="_blank"} _MeasurementKit_ is a C++ library supported by M-Lab, supporting integrations outside of the browser. Supported tests include NDT, Neubot, and the OONI test suite.
 * [Murakami](https://github.com/m-lab/murakami) - _Murakami_ is a tool for creating an automatic M-Lab testing platform with as little effort as possible. Once running, Murakami runs an NDT test roughly every twelve hours and stores the results for your analysis.
 * [Telescope](https://github.com/m-lab/telescope){:target="_blank"} - _Telescope_ is a Python framework designed to extract raw measurements from M-Lab to allow the easy production of research.
+
 ## Community
 
 Community tools are developed by other organizations or individuals, but which leverage the M-Lab platform and data. If you are interested in listing your community tool here, please [contact us](mailto: support@measurementlab.net).

--- a/_pages/datatools.md
+++ b/_pages/datatools.md
@@ -15,10 +15,10 @@ Supported tools are those which have been developed and are maintained by the co
 
 * [M-Lab Measure Chrome App](https://chrome.google.com/webstore/detail/m-lab-measure/leijmacehibmiomcnpaolboihcdepokh?utm_source=chrome-app-launcher-info-dialog){:target="_blank"} - _M-Lab Measure_ is an extension for the Google Chrome browser that lets users schedule NDT to run at regular intervals to track the performance of and Internet connection over time.
 * [MeasurementKit](https://measurement-kit.github.io/){:target="_blank"} _MeasurementKit_ is a C++ library supported by M-Lab, supporting integrations outside of the browser. Supported tests include NDT, Neubot, and the OONI test suite.
-* [Murakami](https://github.com/m-lab/murakami) - Murakami is a tool for creating an automatic M-Lab testing platform with as little effort as possible. Once running, Murakami runs an NDT test roughly every twelve hours and stores the results for your analysis.
+* [Murakami](https://github.com/m-lab/murakami) - _Murakami_ is a tool for creating an automatic M-Lab testing platform with as little effort as possible. Once running, Murakami runs an NDT test roughly every twelve hours and stores the results for your analysis.
 * [Telescope](https://github.com/m-lab/telescope){:target="_blank"} - _Telescope_ is a Python framework designed to extract raw measurements from M-Lab to allow the easy production of research.
 ## Community
 
 Community tools are developed by other organizations or individuals, but which leverage the M-Lab platform and data. If you are interested in listing your community tool here, please [contact us](mailto: support@measurementlab.net).
 
-* [Piecewise](https://github.com/opentechinstitute/piecewise){:target="_blank"} - Piecewise is a tool for digesting and aggregating user-volunteered Internet performance test results data from Measurement Lab, and visualizing aggregate data on the web.
+* [Piecewise](https://github.com/opentechinstitute/piecewise){:target="_blank"} - _Piecewise_ is a tool for digesting and aggregating user-volunteered Internet performance test results data from Measurement Lab, and visualizing aggregate data on the web.

--- a/_pages/datatools.md
+++ b/_pages/datatools.md
@@ -14,7 +14,7 @@ This page describes software tools that can be used to run M-Lab tests and acces
 Supported tools are those which have been developed and are maintained by the core M-Lab staff.
 
 * [M-Lab Measure Chrome App](https://chrome.google.com/webstore/detail/m-lab-measure/leijmacehibmiomcnpaolboihcdepokh?utm_source=chrome-app-launcher-info-dialog){:target="_blank"} - _M-Lab Measure_ is an extension for the Google Chrome browser that lets users schedule NDT to run at regular intervals to track the performance of and Internet connection over time.
-* [MeasurementKit](https://measurement-kit.github.io/){:target="_blank"} _MeasurementKit_ is a C++ library supported by M-Lab, supporting integrations outside of the browser. Supported tests include NDT, Neubot, and the OONI test suite.
+* [MeasurementKit](https://measurement-kit.github.io/){:target="_blank"} - _MeasurementKit_ is a C++ library supported by M-Lab, supporting integrations outside of the browser. Supported tests include NDT, Neubot, and the OONI test suite.
 * [Murakami](https://github.com/m-lab/murakami) - _Murakami_ is a tool for creating an automatic M-Lab testing platform with as little effort as possible. Once running, Murakami runs an NDT test roughly every twelve hours and stores the results for your analysis.
 * [Telescope](https://github.com/m-lab/telescope){:target="_blank"} - _Telescope_ is a Python framework designed to extract raw measurements from M-Lab to allow the easy production of research.
 


### PR DESCRIPTION
This PR adds MeasurementKit and Murakami to the _data/tools_ page, orders the tools alphabetically and adds consistent formatting on the tool name in the description. With the previous addition of the Developer page, this PR resolves #240 . 

Content is previewable on my fork: https://critzo.github.io/m-lab.github.io/data/tools/

@georgiamoon PTAL?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/359)
<!-- Reviewable:end -->
