### PR TITLE
Add blog post about murakami

### DIFF
--- a/_pages/dates/2018-04.md
+++ b/_pages/dates/2018-04.md
@@ -1,0 +1,8 @@
+---
+layout: blog-archive
+title: "April 2018"
+permalink: /blog/2018/04/
+archive-name: April 2018
+archive-type: Monthly
+breadcrumb: blog
+---

--- a/_posts/blog/2018-04-05-murakami.md
+++ b/_posts/blog/2018-04-05-murakami.md
@@ -1,0 +1,23 @@
+---
+layout: blog
+title: "Say Hello to Murakami"
+author: "Ross Schulman"
+date: 2018-04-05
+breadcrumb: blog
+categories:
+  - data
+  - open source
+  - research
+---
+
+# There's a New Way to Run Measurement Lab Tests
+{% include post-meta.html %}
+
+The Measurement Lab team has always tried to make it as easy as possible to run network measurements. Currently, most users run tests either directly from [the M-Lab website](https://www.measurementlab.net/tests/), or through a 3rd party integration. Over the years, many users have requested the ability to run tests on a regular basis, e.g. daily or weekly to collect data over time. Today, we’re releasing a tool that will help you do just that.
+<!--more-->
+
+Welcome [Murakami](https://github.com/m-lab/murakami). The program is quite simple -- it automatically runs an NDT test on average every 12 hours. The output of each test is stored locally and summarized into one file for easy analysis. Murakami is embedded in a Docker container, so that anyone comfortable with Docker (or tinkering!) can easily download and run it. If you aren’t familiar with [Docker](https://www.docker.com/), it is a technology that wraps up everything a program needs to run into one file.
+
+To save you from having to leave your laptop turned on all the time, we’ve targeted the program to run on the [Raspberry Pi platform](https://www.raspberrypi.org/). Raspberry Pis are inexpensive computers about the size of a credit card. After plugging one in and setting Murakami to run, you can forget about the whole thing until you want to dig into the great data that it creates for you. Detailed instructions on installation on Raspberry Pi are in [the Github repository](https://github.com/m-lab/murakami). In addition to being inexpensive and to consuming very little power, Raspberry Pis have the advantage that, when deployed on premises, they allow to collect regular, longitudinal measurements from a stable vantage point. That is, measurements collected at regular intervals provide researchers with a more realistic picture of how internet performance vary across the day and over the years. This is especially useful in case of sudden performance problems, perhaps caused by outages or peering disputes between providers, because there is a wealth of historical data to compare to.
+
+Up next, we plan to develop a dashboard for Murakami, so it’s even easier to review and analyze your data. Let us know if you are interested in collaborating, and feel free to email [contact@measurementlab.net](mailto:contact@measurementlab.net) or submit issues on the Github repository to get in touch!


### PR DESCRIPTION
This PR adds a blog post (which has already been reviewed) about the new `murakami` test platform. It also adds a month entry for `2018-04`.