### PR TITLE
revert to previous spacing in header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -16,7 +16,7 @@
 
   <div class="container">
     <div class="row">
-      <div class="col-xs-2 col-sm-2 col-md-2">
+      <div class="col-xs-2 col-sm-2 col-md-4">
         <h1 class="main-logo"><a href="{{ site.baseurl }}/">{{ header.logo-title }}</a></h1>
       </div>
 


### PR DESCRIPTION
@georgiamoon This PR completes the work that was reverted last night, restoring the spacing in the header between the text and logo: https://critzo.github.io/m-lab.github.io/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/391)
<!-- Reviewable:end -->
