### PR TITLE
update raw storage location; link for JSOR publication

### DIFF
--- a/_pages/04-data.md
+++ b/_pages/04-data.md
@@ -9,7 +9,7 @@ breadcrumb: data
 
 # Overview
 
-Data collected by M-Lab hosted tests that use our ETL pipeline are published in two forms:
+Measurement data from experiments hosted on M-Lab, and processed via the ETL pipeline, are published in two forms:
 
 * Google Cloud Storage
   * M-Lab publishes raw output from its measurement tools on Google Cloud Storage as file archives.
@@ -20,13 +20,15 @@ Data collected by M-Lab hosted tests that use our ETL pipeline are published in 
 
 There is typically at least a 24-hour delay between data collection and data publication. Below we provide links to data for our **Active tests** and archival data from **Inactive tests**.
 
-M-Lab also publishes public datasets about the M-Lab Platform, listed below.
+M-Lab also publishes public data sets about the M-Lab Platform, listed below.
 
 Lastly, some M-Lab hosted tests do not use our ETL pipeline. Data for these tests are published independently by the test developers.
 
-## Data for M-Lab Tests Using the ETL pipeline
+## Current Active Data Sets
 
-### Active Tests
+### Measurement Data (Active Tests)
+
+#### ETL Processed
 
 * [Neubot](https://console.developers.google.com/storage/browser/archive-measurement-lab/neubot/){:target="_blank"}
   * Neubot measures the Internet in order to gather data useful to study broadband performance, network neutrality, and Internet censorship.
@@ -43,14 +45,29 @@ Lastly, some M-Lab hosted tests do not use our ETL pipeline. Data for these test
 * [Paris Traceroute](https://console.developers.google.com/storage/browser/archive-measurement-lab/paris-traceroute/){:target="_blank"}
   * Paris Traceroute maps network topology between two points on the Internet.
   * More information is available at [Paris Traceroute](http://www.paris-traceroute.net/){:target="_blank"}
-* [SamKnows](https://www.samknows.com/){:target="_blank"}
-  * The SamKnows performance testing platform is used by the USA's Federal Communications Commission (FCC), European Commission, UK government (Ofcom), Brazilian government (Anatel), Singapore's IDA and other government-backed studies worldwide.
-  * SamKnows infrastructure includes off-net test servers hosted by M-Lab, and the M-Lab and SamKnows teams coordinate regularly to support the various regulatory reporting periods of data collection conducted by SamKnows.
 * [SideStream](https://console.developers.google.com/storage/browser/archive-measurement-lab/sidestream/){:target="_blank"}
   * SideStream collects TCP state information about completed TCP connections on a system.
   * More information is available on [Github](https://github.com/npad/sidestream){:target="_blank"}.
 
-### Inactive Tests
+#### non-ETL Processed
+
+* [BISmark](http://uploads.projectbismark.net/){:target="_blank"}
+* [MobiPerf](https://console.cloud.google.com/storage/browser/openmobiledata_public){:target="_blank"}
+* [Reverse Traceroute](https://console.cloud.google.com/storage/browser/m-lab_revtr){:target="_blank"}
+* [SamKnows](https://www.samknows.com/){:target="_blank"}
+  * The SamKnows performance testing platform is used by the USA's Federal Communications Commission (FCC), European Commission, UK government (Ofcom), Brazilian government (Anatel), Singapore's IDA and other government-backed studies worldwide.
+  * SamKnows infrastructure includes off-net test servers hosted by M-Lab, and the M-Lab and SamKnows teams coordinate regularly to support the various regulatory reporting periods of data collection conducted by SamKnows.
+
+### Measurement Data (Platform Data)
+
+* [M-Lab Collectd](https://console.developers.google.com/storage/browser/archive-measurement-lab/utilization/){:target="_blank"}
+  * mlab-collectd is a monitoring tool for M-Lab slices, which collects resource utilization information about all M-Lab servers.
+  * More information is available on [Github](https://github.com/m-lab/collectd-mlab){:target="_blank"}.
+* [M-Lab DISCO Switch Telemetry Data](https://console.developers.google.com/storage/browser/archive-measurement-lab/switch/){:target="_blank"}
+  * Since June 2016, M-Lab has collected high resolution switch telemetry for each M-Lab server and site uplink. The **DIS**card **CO**llection (a.k.a. DISCO) dataset is also published as a standard M-Lab BigQuery table: `measurement-lab.base_tables.switch`
+  * Our [blog post announcing this dataset]({{site.baseurl}}/blog/disco-dataset/#new-disco-switch-telemetry-dataset) provides more information about the DISCO dataset.
+
+### Historical Data Sets (e.g. Retired Tests)
 
 * [Glasnost](https://console.developers.google.com/storage/browser/archive-measurement-lab/glasnost/){:target="_blank"} (**deprecated**)
   * Glasnost detects prioritization or censorship of network traffic.
@@ -62,22 +79,6 @@ Lastly, some M-Lab hosted tests do not use our ETL pipeline. Data for these test
 * [ShaperProbe](https://console.developers.google.com/storage/browser/archive-measurement-lab/shaperprobe/){:target="_blank"} (**deprecated**)
   * **M-Lab no longer supports this tool, but its archived data are available on GCS.**
   * ShaperProbe detected prioritization of network traffic.
-
-## Links to Public M-Lab Platform Data
-
-* [M-Lab Collectd](https://console.developers.google.com/storage/browser/archive-measurement-lab/utilization/){:target="_blank"}
-  * mlab-collectd is a monitoring tool for M-Lab slices, which collects resource utilization information about all M-Lab servers.
-  * More information is available on [Github](https://github.com/m-lab/collectd-mlab){:target="_blank"}.
-* [M-Lab DISCO Switch Telemetry Data](https://console.developers.google.com/storage/browser/archive-measurement-lab/switch/){:target="_blank"}
-  * Since June 2016, M-Lab has collected high resolution switch telemetry for each M-Lab server and site uplink. The **DIS**card **CO**llection (a.k.a. DISCO) dataset is also published as a standard M-Lab BigQuery table: `measurement-lab.base_tables.switch`
-  * Our [blog post announcing this dataset]({{site.baseurl}}/blog/disco-dataset/#new-disco-switch-telemetry-dataset) provides more information about the DISCO dataset.
-
-## Data for M-Lab Tests Published Elsewhere by Test Developers
-
-* [BISmark](http://uploads.projectbismark.net/){:target="_blank"}
-* [MobiPerf](https://console.cloud.google.com/storage/browser/openmobiledata_public){:target="_blank"}
-* [Reverse Traceroute](https://console.cloud.google.com/storage/browser/m-lab_revtr){:target="_blank"}
-* [SamKnows](https://www.samknows.com/){:target="_blank"}
 
 ## Data License and Citing M-Lab Data
 

--- a/_pages/04-data.md
+++ b/_pages/04-data.md
@@ -9,76 +9,75 @@ breadcrumb: data
 
 # Overview
 
-Measurement data from experiments hosted on M-Lab, and processed via the ETL pipeline, are published in two forms:
+Measurement data from many experiments hosted on M-Lab are processed via the ETL pipeline and published in two forms:
 
 * Google Cloud Storage
-  * M-Lab publishes raw output from its measurement tools on Google Cloud Storage as file archives.
+  * M-Lab publishes raw output from many measurement tests on Google Cloud Storage as file archives.
   * See [M-Lab Google Cloud Storage documentation]({{ site.baseurl }}/data/docs/gcs) for more information.
 * Google BigQuery
-  * M-Lab parses data for a subset of its tools and publishes the data on BigQuery so that users can run SQL queries on the data.
+  * M-Lab parses data for a subset of tests and publishes the data on BigQuery so that users can run SQL queries on the data.
   * See [M-Lab BigQuery QuickStart]({{ site.baseurl }}/data/docs/bq/quickstart) for more information.
+
+Some M-Lab hosted tests do not use our ETL pipeline. Data for these tests are published independently by the test developers.
 
 There is typically at least a 24-hour delay between data collection and data publication. Below we provide links to data for our **Active tests** and archival data from **Inactive tests**.
 
 M-Lab also publishes public data sets about the M-Lab Platform, listed below.
 
-Lastly, some M-Lab hosted tests do not use our ETL pipeline. Data for these tests are published independently by the test developers.
+## Measurement Data (Active Tests)
 
-## Current Active Data Sets
-
-### Measurement Data (Active Tests)
-
-#### ETL Processed
-
-* [Neubot](https://console.developers.google.com/storage/browser/archive-measurement-lab/neubot/){:target="_blank"}
-  * Neubot measures the Internet in order to gather data useful to study broadband performance, network neutrality, and Internet censorship.
+* [BISmark]({{site.baseurl}}/tests/bismark) - BISmark measures Internet service provider (ISP) performance and traffic inside home networks. BISmark data is not processed by the M-Lab ETL Pipeline.
+  * More information is availabla on the [Project BISmark website](http://projectbismark.net/){:target="_blank"}
+  * [BISmark Raw Data](http://uploads.projectbismark.net/){:target="_blank"}
+* [MobiPerf]({{site.baseurl}}/tests/mobiperf) - MobiPerf is an open source application for measuring network performance on mobile platforms. MobiPerf data is not processed by the M-Lab ETL Pipeline.
+  * More information is available on the [MobiPerf website](http://www.mobiperf.com/){:target="_blank"}
+  * [MobiPerf Raw Data](https://console.cloud.google.com/storage/browser/openmobiledata_public){:target="_blank"}
+* [Neubot]({{site.baseurl}}/tests/neubot) - Neubot measures the Internet in order to gather data useful to study broadband performance, network neutrality, and Internet censorship. Neubot data is processed by the M-Lab ETL Pipeline.
   * More information is available at [Nexa Center](https://neubot.nexacenter.org/){:target="_blank"} and [Github](https://github.com/neubot){:target="_blank"}.
-* [NDT](https://console.developers.google.com/storage/browser/archive-measurement-lab/ndt/){:target="_blank"}
-  * Network Diagnostic Tool (NDT) measures characteristics of a TCP connection under heavy load.
+  * [Neubot Raw Data](https://console.developers.google.com/storage/browser/archive-measurement-lab/neubot/){:target="_blank"}
+* [NDT]({{site.baseurl}}/tests/ndt) - Network Diagnostic Tool (NDT) measures characteristics of a TCP connection under heavy load. NDT data is processed by the M-Lab ETL Pipeline.
   * More information is available at [Internet2](http://software.internet2.edu/ndt/){:target="_blank"} and [Github](https://github.com/ndt-project/ndt){:target="_blank"}.
-* [NPAD](https://console.developers.google.com/storage/browser/archive-measurement-lab/npad/){:target="_blank"}
-  * Network Path and Application Diagnosis (NPAD) diagnoses issues in a network path that can degrade network performance.
-  * More information is available at [UCAR](https://web.archive.org/web/20180714140225/https://www.ucar.edu/npad/){:target="_blank"} and [Github](https://github.com/npad/npad){:target="_blank"}.
-* [OONI](https://console.developers.google.com/storage/browser/archive-measurement-lab/ooni/){:target="_blank"}
-  * OONI measures censorship, surveillance, and traffic manipulation on the Internet.
+  * [NDT Raw Data](https://console.developers.google.com/storage/browser/archive-measurement-lab/ndt/){:target="_blank"} - [NDT BigQuery Dataset](https://bigquery.cloud.google.com/dataset/measurement-lab:release)
+* [NPAD]({{site.baseurl}}/tests/npad) - Network Path and Application Diagnosis (NPAD) diagnoses issues in a network path that can degrade network performance. NPAD data is processed by the M-Lab ETL Pipeline.
+  * More information is available from archived [UCAR](https://web.archive.org/web/20180714140225/https://www.ucar.edu/npad/){:target="_blank"} pages and [Github](https://github.com/npad/npad){:target="_blank"}.
+  * [NPAD Raw Data](https://console.developers.google.com/storage/browser/archive-measurement-lab/npad/){:target="_blank"}
+* [OONI]({{site.baseurl}}/tests/ooni) - OONI measures censorship, surveillance, and traffic manipulation on the Internet. OONI data is not processed by the M-Lab ETL Pipeline.
   * More information is available at [OONI](https://ooni.torproject.org/){:target="_blank"}
-* [Paris Traceroute](https://console.developers.google.com/storage/browser/archive-measurement-lab/paris-traceroute/){:target="_blank"}
-  * Paris Traceroute maps network topology between two points on the Internet.
+  * [OONI Raw Data](https://console.developers.google.com/storage/browser/archive-measurement-lab/ooni/){:target="_blank"}
+* [Paris Traceroute]({{site.baseurl}}/tests/paris_traceroute) - Paris Traceroute maps network topology between two points on the Internet. Paris Traceroute data is processed by the M-Lab ETL Pipeline.
   * More information is available at [Paris Traceroute](http://www.paris-traceroute.net/){:target="_blank"}
-* [SideStream](https://console.developers.google.com/storage/browser/archive-measurement-lab/sidestream/){:target="_blank"}
-  * SideStream collects TCP state information about completed TCP connections on a system.
-  * More information is available on [Github](https://github.com/npad/sidestream){:target="_blank"}.
-
-#### non-ETL Processed
-
-* [BISmark](http://uploads.projectbismark.net/){:target="_blank"}
-* [MobiPerf](https://console.cloud.google.com/storage/browser/openmobiledata_public){:target="_blank"}
-* [Reverse Traceroute](https://console.cloud.google.com/storage/browser/m-lab_revtr){:target="_blank"}
-* [SamKnows](https://www.samknows.com/){:target="_blank"}
-  * The SamKnows performance testing platform is used by the USA's Federal Communications Commission (FCC), European Commission, UK government (Ofcom), Brazilian government (Anatel), Singapore's IDA and other government-backed studies worldwide.
+  * [Paris Traceroute Raw Data](https://console.developers.google.com/storage/browser/archive-measurement-lab/paris-traceroute/){:target="_blank"} - [Paris Traceroute BigQuery Dataset](https://bigquery.cloud.google.com/table/measurement-lab:base_tables.traceroute){:target="_blank"}
+* [Reverse Traceroute]({{site.baseurl}}/tests/reverse_traceroute) - Reverse traceroute measures the network path back to a user from selected network endpoints, and provides a rich source of information on network routing and topology. Reverse Traceroute data is not processed by the M-Lab ETL Pipeline.
+  * More information is available at [Reverse Traceroute](https://research.cs.washington.edu/networking/astronomy/reverse-traceroute.html){:target="_blank"}
+  * [Reverse Traceroute Raw Data](https://console.cloud.google.com/storage/browser/m-lab_revtr){:target="_blank"}
+* [SamKnows]({{site.baseurl}}/tests/samknows) - The SamKnows performance testing platform is used by the USA's Federal Communications Commission (FCC), European Commission, UK government (Ofcom), Brazilian government (Anatel), Singapore's IDA and other government-backed studies worldwide.
   * SamKnows infrastructure includes off-net test servers hosted by M-Lab, and the M-Lab and SamKnows teams coordinate regularly to support the various regulatory reporting periods of data collection conducted by SamKnows.
+  * More information is available at the [SamKnows website](https://www.samknows.com/){:target="_blank"}
+* [SideStream]({{site.baseurl}}/tests/sidestream) - SideStream collects TCP state information about completed TCP connections on a system. Sidestream data is processed by the M-Lab ETL Pipeline.
+  * More information is available on [Github](https://github.com/npad/sidestream){:target="_blank"}.
+  * [Sidestream Raw Data](https://console.developers.google.com/storage/browser/archive-measurement-lab/sidestream/){:target="_blank"} - [Sidestream BigQuery Dataset](https://bigquery.cloud.google.com/dataset/measurement-lab:sidestream){:target="_blank"}
 
-### Measurement Data (Platform Data)
+## Measurement Data (Platform Data)
 
-* [M-Lab Collectd](https://console.developers.google.com/storage/browser/archive-measurement-lab/utilization/){:target="_blank"}
-  * mlab-collectd is a monitoring tool for M-Lab slices, which collects resource utilization information about all M-Lab servers.
+* [M-Lab Collectd](https://github.com/m-lab/collectd-mlab){:target="_blank"} - M-Lab Collectd is a monitoring tool for M-Lab slices, which collects resource utilization information about all M-Lab servers.
   * More information is available on [Github](https://github.com/m-lab/collectd-mlab){:target="_blank"}.
-* [M-Lab DISCO Switch Telemetry Data](https://console.developers.google.com/storage/browser/archive-measurement-lab/switch/){:target="_blank"}
-  * Since June 2016, M-Lab has collected high resolution switch telemetry for each M-Lab server and site uplink. The **DIS**card **CO**llection (a.k.a. DISCO) dataset is also published as a standard M-Lab BigQuery table: `measurement-lab.base_tables.switch`
-  * Our [blog post announcing this dataset]({{site.baseurl}}/blog/disco-dataset/#new-disco-switch-telemetry-dataset) provides more information about the DISCO dataset.
+  * [M-Lab Collectd Raw Data](https://console.developers.google.com/storage/browser/archive-measurement-lab/utilization/){:target="_blank"}.
+* [M-Lab DISCO Switch Telemetry Data](https://console.developers.google.com/storage/browser/archive-measurement-lab/switch/){:target="_blank"} - Since June 2016, M-Lab has collected high resolution switch telemetry for each M-Lab server and site uplink and published it as the **DIS**card **CO**llection (a.k.a. DISCO) dataset.
+  * More information is available in the [blog post announcing this dataset]({{site.baseurl}}/blog/disco-dataset/#new-disco-switch-telemetry-dataset) provides more information about the DISCO dataset.
+  * [M-Lab DISCO Raw Data](https://console.developers.google.com/storage/browser/archive-measurement-lab/switch/){:target="_blank"} - [M-Lab DISCO BigQuery Dataset](https://bigquery.cloud.google.com/table/measurement-lab:base_tables.switch){:target="_blank"}
 
-### Historical Data Sets (e.g. Retired Tests)
+## Historical Data Sets (e.g. Retired Tests)
 
-* [Glasnost](https://console.developers.google.com/storage/browser/archive-measurement-lab/glasnost/){:target="_blank"} (**deprecated**)
-  * Glasnost detects prioritization or censorship of network traffic.
+* [Glasnost]({{site.baseurl}}/tests/glasnost) - Glasnost detected prioritization or censorship of network traffic.
   * More information is available at [MPI SWS](http://broadband.mpi-sws.org/transparency/bttest-mlab.php){:target="_blank"} and [Github](https://github.com/marcelscode/glasnost){:target="_blank"}.
-* [pathload2](https://console.developers.google.com/storage/browser/archive-measurement-lab/pathload2/){:target="_blank"} (**deprecated**)
-  * **M-Lab no longer supports this tool, but its archived data are available on GCS. For similar measurements with a current and supported tool, see NDT.**
-  * Pathload2 measures the available bandwidth of an Internet connection.
+  * [Glasnost Raw Data (archived)](https://console.developers.google.com/storage/browser/archive-measurement-lab/glasnost/){:target="_blank"}
+* [Pathload2]({{site.baseurl}}/tests/pathload2) - Pathload2 measured the available bandwidth of an Internet connection.
   * More information is available at [https://code.google.com/p/pathload2-gatech/](https://code.google.com/p/pathload2-gatech/){:target="_blank"}.
-* [ShaperProbe](https://console.developers.google.com/storage/browser/archive-measurement-lab/shaperprobe/){:target="_blank"} (**deprecated**)
-  * **M-Lab no longer supports this tool, but its archived data are available on GCS.**
-  * ShaperProbe detected prioritization of network traffic.
+  * [Pathload2 Raw Data (archived)](https://console.developers.google.com/storage/browser/archive-measurement-lab/pathload2/){:target="_blank"}
+* [ShaperProbe]({{site.baseurl}}/tests/shaperprobe) - ShaperProbe detected prioritization of network traffic.
+  * [Shaperprobe Raw Data (archived)](https://console.developers.google.com/storage/browser/archive-measurement-lab/shaperprobe/){:target="_blank"}
+* [Windrider]({{site.baseurl}}/tests/windrider) - WindRider attempted to detect whether your mobile provider was performing application- or service-specific differentiation.
+  * More information is available at [Windrider](http://www.cs.northwestern.edu/~ict992/mobile.htm){:target="_blank"}.
 
 ## Data License and Citing M-Lab Data
 

--- a/_pages/04-data.md
+++ b/_pages/04-data.md
@@ -9,7 +9,7 @@ breadcrumb: data
 
 # Overview
 
-M-Lab publishes its test data in two forms:
+Data collected by M-Lab hosted tests that use our ETL pipeline are published in two forms:
 
 * Google Cloud Storage
   * M-Lab publishes raw output from its measurement tools on Google Cloud Storage as file archives.
@@ -18,49 +18,66 @@ M-Lab publishes its test data in two forms:
   * M-Lab parses data for a subset of its tools and publishes the data on BigQuery so that users can run SQL queries on the data.
   * See [M-Lab BigQuery QuickStart]({{ site.baseurl }}/data/docs/bq/quickstart) for more information.
 
-There is typically at least a 24-hour delay between data collection and data publication.
+There is typically at least a 24-hour delay between data collection and data publication. Below we provide links to data for our **Active tests** and archival data from **Inactive tests**.
 
-## Links to Raw Data for M-Lab Tests
+M-Lab also publishes public datasets about the M-Lab Platform, listed below.
+
+Lastly, some M-Lab hosted tests do not use our ETL pipeline. Data for these tests are published independently by the test developers.
+
+## Data for M-Lab Tests Using the ETL pipeline
 
 ### Active Tests
 
-* [M-Lab Collectd](https://console.developers.google.com/storage/browser/m-lab/utilization/){:target="_blank"}
-  * mlab-collectd is a monitoring tool for M-Lab slices, which collects resource utilization information about all M-Lab servers.
-  * More information is available on [Github](https://github.com/m-lab/collectd-mlab){:target="_blank"}.
-* [Neubot](https://console.developers.google.com/storage/browser/m-lab/neubot/){:target="_blank"}
+* [Neubot](https://console.developers.google.com/storage/browser/archive-measurement-lab/neubot/){:target="_blank"}
   * Neubot measures the Internet in order to gather data useful to study broadband performance, network neutrality, and Internet censorship.
   * More information is available at [Nexa Center](https://neubot.nexacenter.org/){:target="_blank"} and [Github](https://github.com/neubot){:target="_blank"}.
-* [NDT](https://console.developers.google.com/storage/browser/m-lab/ndt/){:target="_blank"}
+* [NDT](https://console.developers.google.com/storage/browser/archive-measurement-lab/ndt/){:target="_blank"}
   * Network Diagnostic Tool (NDT) measures characteristics of a TCP connection under heavy load.
   * More information is available at [Internet2](http://software.internet2.edu/ndt/){:target="_blank"} and [Github](https://github.com/ndt-project/ndt){:target="_blank"}.
-* [NPAD](https://console.developers.google.com/storage/browser/m-lab/npad/){:target="_blank"}
+* [NPAD](https://console.developers.google.com/storage/browser/archive-measurement-lab/npad/){:target="_blank"}
   * Network Path and Application Diagnosis (NPAD) diagnoses issues in a network path that can degrade network performance.
   * More information is available at [UCAR](https://web.archive.org/web/20180714140225/https://www.ucar.edu/npad/){:target="_blank"} and [Github](https://github.com/npad/npad){:target="_blank"}.
-* [OONI](https://console.developers.google.com/storage/browser/m-lab/ooni/){:target="_blank"}
+* [OONI](https://console.developers.google.com/storage/browser/archive-measurement-lab/ooni/){:target="_blank"}
   * OONI measures censorship, surveillance, and traffic manipulation on the Internet.
   * More information is available at [OONI](https://ooni.torproject.org/){:target="_blank"}
-* [Paris Traceroute](https://console.developers.google.com/storage/browser/m-lab/paris-traceroute/){:target="_blank"}
+* [Paris Traceroute](https://console.developers.google.com/storage/browser/archive-measurement-lab/paris-traceroute/){:target="_blank"}
   * Paris Traceroute maps network topology between two points on the Internet.
   * More information is available at [Paris Traceroute](http://www.paris-traceroute.net/){:target="_blank"}
 * [SamKnows](https://www.samknows.com/){:target="_blank"}
   * The SamKnows performance testing platform is used by the USA's Federal Communications Commission (FCC), European Commission, UK government (Ofcom), Brazilian government (Anatel), Singapore's IDA and other government-backed studies worldwide.
   * SamKnows infrastructure includes off-net test servers hosted by M-Lab, and the M-Lab and SamKnows teams coordinate regularly to support the various regulatory reporting periods of data collection conducted by SamKnows.
-* [SideStream](https://console.developers.google.com/storage/browser/m-lab/sidestream/){:target="_blank"}
+* [SideStream](https://console.developers.google.com/storage/browser/archive-measurement-lab/sidestream/){:target="_blank"}
   * SideStream collects TCP state information about completed TCP connections on a system.
   * More information is available on [Github](https://github.com/npad/sidestream){:target="_blank"}.
 
 ### Inactive Tests
 
-* [Glasnost](https://console.developers.google.com/storage/browser/m-lab/glasnost/){:target="_blank"} (**deprecated**)
+* [Glasnost](https://console.developers.google.com/storage/browser/archive-measurement-lab/glasnost/){:target="_blank"} (**deprecated**)
   * Glasnost detects prioritization or censorship of network traffic.
   * More information is available at [MPI SWS](http://broadband.mpi-sws.org/transparency/bttest-mlab.php){:target="_blank"} and [Github](https://github.com/marcelscode/glasnost){:target="_blank"}.
-* [pathload2](https://console.developers.google.com/storage/browser/m-lab/pathload2/){:target="_blank"} (**deprecated**)
+* [pathload2](https://console.developers.google.com/storage/browser/archive-measurement-lab/pathload2/){:target="_blank"} (**deprecated**)
   * **M-Lab no longer supports this tool, but its archived data are available on GCS. For similar measurements with a current and supported tool, see NDT.**
   * Pathload2 measures the available bandwidth of an Internet connection.
   * More information is available at [https://code.google.com/p/pathload2-gatech/](https://code.google.com/p/pathload2-gatech/){:target="_blank"}.
-* [ShaperProbe](https://console.developers.google.com/storage/browser/m-lab/shaperprobe/){:target="_blank"} (**deprecated**)
+* [ShaperProbe](https://console.developers.google.com/storage/browser/archive-measurement-lab/shaperprobe/){:target="_blank"} (**deprecated**)
   * **M-Lab no longer supports this tool, but its archived data are available on GCS.**
   * ShaperProbe detected prioritization of network traffic.
+
+## Links to Public M-Lab Platform Data
+
+* [M-Lab Collectd](https://console.developers.google.com/storage/browser/archive-measurement-lab/utilization/){:target="_blank"}
+  * mlab-collectd is a monitoring tool for M-Lab slices, which collects resource utilization information about all M-Lab servers.
+  * More information is available on [Github](https://github.com/m-lab/collectd-mlab){:target="_blank"}.
+* [M-Lab DISCO Switch Telemetry Data](https://console.developers.google.com/storage/browser/archive-measurement-lab/switch/){:target="_blank"}
+  * Since June 2016, M-Lab has collected high resolution switch telemetry for each M-Lab server and site uplink. The **DIS**card **CO**llection (a.k.a. DISCO) dataset is also published as a standard M-Lab BigQuery table: `measurement-lab.base_tables.switch`
+  * Our [blog post announcing this dataset]({{site.baseurl}}/blog/disco-dataset/#new-disco-switch-telemetry-dataset) provides more information about the DISCO dataset.
+
+## Data for M-Lab Tests Published Elsewhere by Test Developers
+
+* [BISmark](http://uploads.projectbismark.net/){:target="_blank"}
+* [MobiPerf](https://console.cloud.google.com/storage/browser/openmobiledata_public){:target="_blank"}
+* [Reverse Traceroute](https://console.cloud.google.com/storage/browser/m-lab_revtr){:target="_blank"}
+* [SamKnows](https://www.samknows.com/){:target="_blank"}
 
 ## Data License and Citing M-Lab Data
 

--- a/_pages/04-data.md
+++ b/_pages/04-data.md
@@ -26,57 +26,73 @@ M-Lab also publishes public data sets about the M-Lab Platform, listed below.
 
 ## Measurement Data (Active Tests)
 
-* [BISmark]({{site.baseurl}}/tests/bismark) - BISmark measures Internet service provider (ISP) performance and traffic inside home networks. BISmark data is not processed by the M-Lab ETL Pipeline.
+* [BISmark]({{site.baseurl}}/tests/bismark)
+  * BISmark measures Internet service provider (ISP) performance and traffic inside home networks. BISmark data is not processed by the M-Lab ETL Pipeline.
   * More information is availabla on the [Project BISmark website](http://projectbismark.net/){:target="_blank"}
   * [BISmark Raw Data](http://uploads.projectbismark.net/){:target="_blank"}
-* [MobiPerf]({{site.baseurl}}/tests/mobiperf) - MobiPerf is an open source application for measuring network performance on mobile platforms. MobiPerf data is not processed by the M-Lab ETL Pipeline.
+* [MobiPerf]({{site.baseurl}}/tests/mobiperf)
+  * MobiPerf is an open source application for measuring network performance on mobile platforms. MobiPerf data is not processed by the M-Lab ETL Pipeline.
   * More information is available on the [MobiPerf website](http://www.mobiperf.com/){:target="_blank"}
   * [MobiPerf Raw Data](https://console.cloud.google.com/storage/browser/openmobiledata_public){:target="_blank"}
-* [Neubot]({{site.baseurl}}/tests/neubot) - Neubot measures the Internet in order to gather data useful to study broadband performance, network neutrality, and Internet censorship. Neubot data is processed by the M-Lab ETL Pipeline.
+* [Neubot]({{site.baseurl}}/tests/neubot)
+  * Neubot measures the Internet in order to gather data useful to study broadband performance, network neutrality, and Internet censorship. Neubot data is processed by the M-Lab ETL Pipeline.
   * More information is available at [Nexa Center](https://neubot.nexacenter.org/){:target="_blank"} and [Github](https://github.com/neubot){:target="_blank"}.
   * [Neubot Raw Data](https://console.developers.google.com/storage/browser/archive-measurement-lab/neubot/){:target="_blank"}
-* [NDT]({{site.baseurl}}/tests/ndt) - Network Diagnostic Tool (NDT) measures characteristics of a TCP connection under heavy load. NDT data is processed by the M-Lab ETL Pipeline.
+* [NDT]({{site.baseurl}}/tests/ndt)
+  * Network Diagnostic Tool (NDT) measures characteristics of a TCP connection under heavy load. NDT data is processed by the M-Lab ETL Pipeline.
   * More information is available at [Internet2](http://software.internet2.edu/ndt/){:target="_blank"} and [Github](https://github.com/ndt-project/ndt){:target="_blank"}.
   * [NDT Raw Data](https://console.developers.google.com/storage/browser/archive-measurement-lab/ndt/){:target="_blank"} - [NDT BigQuery Dataset](https://bigquery.cloud.google.com/dataset/measurement-lab:release)
-* [NPAD]({{site.baseurl}}/tests/npad) - Network Path and Application Diagnosis (NPAD) diagnoses issues in a network path that can degrade network performance. NPAD data is processed by the M-Lab ETL Pipeline.
+* [NPAD]({{site.baseurl}}/tests/npad)
+  * Network Path and Application Diagnosis (NPAD) diagnoses issues in a network path that can degrade network performance. NPAD data is processed by the M-Lab ETL Pipeline.
   * More information is available from archived [UCAR](https://web.archive.org/web/20180714140225/https://www.ucar.edu/npad/){:target="_blank"} pages and [Github](https://github.com/npad/npad){:target="_blank"}.
   * [NPAD Raw Data](https://console.developers.google.com/storage/browser/archive-measurement-lab/npad/){:target="_blank"}
-* [OONI]({{site.baseurl}}/tests/ooni) - OONI measures censorship, surveillance, and traffic manipulation on the Internet. OONI data is not processed by the M-Lab ETL Pipeline.
+* [OONI]({{site.baseurl}}/tests/ooni)
+  * OONI measures censorship, surveillance, and traffic manipulation on the Internet. OONI data is not processed by the M-Lab ETL Pipeline.
   * More information is available at [OONI](https://ooni.torproject.org/){:target="_blank"}
   * [OONI Raw Data](https://console.developers.google.com/storage/browser/archive-measurement-lab/ooni/){:target="_blank"}
-* [Paris Traceroute]({{site.baseurl}}/tests/paris_traceroute) - Paris Traceroute maps network topology between two points on the Internet. Paris Traceroute data is processed by the M-Lab ETL Pipeline.
+* [Paris Traceroute]({{site.baseurl}}/tests/paris_traceroute)
+  * Paris Traceroute maps network topology between two points on the Internet. Paris Traceroute data is processed by the M-Lab ETL Pipeline.
   * More information is available at [Paris Traceroute](http://www.paris-traceroute.net/){:target="_blank"}
   * [Paris Traceroute Raw Data](https://console.developers.google.com/storage/browser/archive-measurement-lab/paris-traceroute/){:target="_blank"} - [Paris Traceroute BigQuery Dataset](https://bigquery.cloud.google.com/table/measurement-lab:base_tables.traceroute){:target="_blank"}
-* [Reverse Traceroute]({{site.baseurl}}/tests/reverse_traceroute) - Reverse traceroute measures the network path back to a user from selected network endpoints, and provides a rich source of information on network routing and topology. Reverse Traceroute data is not processed by the M-Lab ETL Pipeline.
+* [Reverse Traceroute]({{site.baseurl}}/tests/reverse_traceroute)
+  * Reverse traceroute measures the network path back to a user from selected network endpoints, and provides a rich source of information on network routing and topology. Reverse Traceroute data is not processed by the M-Lab ETL Pipeline.
   * More information is available at [Reverse Traceroute](https://research.cs.washington.edu/networking/astronomy/reverse-traceroute.html){:target="_blank"}
   * [Reverse Traceroute Raw Data](https://console.cloud.google.com/storage/browser/m-lab_revtr){:target="_blank"}
-* [SamKnows]({{site.baseurl}}/tests/samknows) - The SamKnows performance testing platform is used by the USA's Federal Communications Commission (FCC), European Commission, UK government (Ofcom), Brazilian government (Anatel), Singapore's IDA and other government-backed studies worldwide.
+* [SamKnows]({{site.baseurl}}/tests/samknows)
+  * The SamKnows performance testing platform is used by the USA's Federal Communications Commission (FCC), European Commission, UK government (Ofcom), Brazilian government (Anatel), Singapore's IDA and other government-backed studies worldwide.
   * SamKnows infrastructure includes off-net test servers hosted by M-Lab, and the M-Lab and SamKnows teams coordinate regularly to support the various regulatory reporting periods of data collection conducted by SamKnows.
   * More information is available at the [SamKnows website](https://www.samknows.com/){:target="_blank"}
-* [SideStream]({{site.baseurl}}/tests/sidestream) - SideStream collects TCP state information about completed TCP connections on a system. Sidestream data is processed by the M-Lab ETL Pipeline.
+* [SideStream]({{site.baseurl}}/tests/sidestream)
+  * SideStream collects TCP state information about completed TCP connections on a system. Sidestream data is processed by the M-Lab ETL Pipeline.
   * More information is available on [Github](https://github.com/npad/sidestream){:target="_blank"}.
   * [Sidestream Raw Data](https://console.developers.google.com/storage/browser/archive-measurement-lab/sidestream/){:target="_blank"} - [Sidestream BigQuery Dataset](https://bigquery.cloud.google.com/dataset/measurement-lab:sidestream){:target="_blank"}
 
 ## Measurement Data (Platform Data)
 
-* [M-Lab Collectd](https://github.com/m-lab/collectd-mlab){:target="_blank"} - M-Lab Collectd is a monitoring tool for M-Lab slices, which collects resource utilization information about all M-Lab servers.
+* [M-Lab Collectd](https://github.com/m-lab/collectd-mlab){:target="_blank"}
+  * M-Lab Collectd is a monitoring tool for M-Lab slices, which collects resource utilization information about all M-Lab servers.
   * More information is available on [Github](https://github.com/m-lab/collectd-mlab){:target="_blank"}.
   * [M-Lab Collectd Raw Data](https://console.developers.google.com/storage/browser/archive-measurement-lab/utilization/){:target="_blank"}.
-* [M-Lab DISCO Switch Telemetry Data](https://console.developers.google.com/storage/browser/archive-measurement-lab/switch/){:target="_blank"} - Since June 2016, M-Lab has collected high resolution switch telemetry for each M-Lab server and site uplink and published it as the **DIS**card **CO**llection (a.k.a. DISCO) dataset.
+* [M-Lab DISCO Switch Telemetry Data](https://console.developers.google.com/storage/browser/archive-measurement-lab/switch/){:target="_blank"}
+  * Since June 2016, M-Lab has collected high resolution switch telemetry for each M-Lab server and site uplink and published it as the **DIS**card **CO**llection (a.k.a. DISCO) dataset.
   * More information is available in the [blog post announcing this dataset]({{site.baseurl}}/blog/disco-dataset/#new-disco-switch-telemetry-dataset) provides more information about the DISCO dataset.
   * [M-Lab DISCO Raw Data](https://console.developers.google.com/storage/browser/archive-measurement-lab/switch/){:target="_blank"} - [M-Lab DISCO BigQuery Dataset](https://bigquery.cloud.google.com/table/measurement-lab:base_tables.switch){:target="_blank"}
 
 ## Historical Data Sets (e.g. Retired Tests)
 
-* [Glasnost]({{site.baseurl}}/tests/glasnost) - Glasnost detected prioritization or censorship of network traffic.
+* [Glasnost]({{site.baseurl}}/tests/glasnost)
+  * Glasnost detected prioritization or censorship of network traffic.
   * More information is available at [MPI SWS](http://broadband.mpi-sws.org/transparency/bttest-mlab.php){:target="_blank"} and [Github](https://github.com/marcelscode/glasnost){:target="_blank"}.
   * [Glasnost Raw Data (archived)](https://console.developers.google.com/storage/browser/archive-measurement-lab/glasnost/){:target="_blank"}
-* [Pathload2]({{site.baseurl}}/tests/pathload2) - Pathload2 measured the available bandwidth of an Internet connection.
+* [Pathload2]({{site.baseurl}}/tests/pathload2)
+  * Pathload2 measured the available bandwidth of an Internet connection.
   * More information is available at [https://code.google.com/p/pathload2-gatech/](https://code.google.com/p/pathload2-gatech/){:target="_blank"}.
   * [Pathload2 Raw Data (archived)](https://console.developers.google.com/storage/browser/archive-measurement-lab/pathload2/){:target="_blank"}
-* [ShaperProbe]({{site.baseurl}}/tests/shaperprobe) - ShaperProbe detected prioritization of network traffic.
+* [ShaperProbe]({{site.baseurl}}/tests/shaperprobe)
+  * ShaperProbe detected prioritization of network traffic.
   * [Shaperprobe Raw Data (archived)](https://console.developers.google.com/storage/browser/archive-measurement-lab/shaperprobe/){:target="_blank"}
-* [Windrider]({{site.baseurl}}/tests/windrider) - WindRider attempted to detect whether your mobile provider was performing application- or service-specific differentiation.
+* [Windrider]({{site.baseurl}}/tests/windrider)
+  * WindRider attempted to detect whether your mobile provider was performing application- or service-specific differentiation.
   * More information is available at [Windrider](http://www.cs.northwestern.edu/~ict992/mobile.htm){:target="_blank"}.
 
 ## Data License and Citing M-Lab Data

--- a/_pages/06-publications.md
+++ b/_pages/06-publications.md
@@ -203,7 +203,7 @@ The interest for Quality of Service (QoS) measurements in the Internet has excee
 {:.paper-author}
 Ioannis Koukoutsidis
 
-[Download PDF](http://www.jstor.org/stable/pdf/10.5325/jinfopoli.5.2015.0245.pdf){:.download-link .paper-download target="_blank"}
+Download link: http://www.jstor.org/stable/pdf/10.5325/jinfopoli.5.2015.0245.pdf
 
 ### European capability for situational awareness
 {:.no_toc}

--- a/_pages/faq.md
+++ b/_pages/faq.md
@@ -107,7 +107,7 @@ M-Lab's measurements are always conducted off-net. This way, M-Lab is able to me
 
 Different Internet performance tests measure different things in different ways. M-Lab's NDT test tries to transfer as much data as it can in ten seconds (both up and down), using a single connection to an M-Lab server. Other popular tests try to transfer as much data as possible at once across multiple connections to their server. Neither method is "right" or "wrong," but using a single stream is more likely to help diagnose problems in the network than multiple streams would. [Learn more about M-Lab's NDT methodology](https://github.com/ndt-project/ndt/wiki/NDTTestMethodology).
 
-All NDT data collected by M-Lab are publicly available in both [visualized]({{ site.baseurl }}/visualizations/) (graphic), [queryable](https://bigquery.cloud.google.com/queries/measurement-lab), and [raw (unanalyzed) forms](https://console.developers.google.com/storage/browser/m-lab/ndt/).
+All NDT data collected by M-Lab are publicly available in both [visualized]({{ site.baseurl }}/visualizations/) (graphic), [queryable](https://bigquery.cloud.google.com/queries/measurement-lab), and [raw (unanalyzed) forms](https://console.developers.google.com/storage/browser/archive-measurement-lab/ndt/).
 
 **3. Changing network conditions and distinct test paths**
 

--- a/_pages/gcs.md
+++ b/_pages/gcs.md
@@ -9,7 +9,7 @@ breadcrumb: data
 
 M-Lab publishes all data it collects in raw form as archives on Google Cloud Storage (GCS) at the following location:
 
-[https://console.developers.google.com/storage/browser/m-lab/](https://console.developers.google.com/storage/browser/m-lab/){:target="_blank"}
+[https://console.developers.google.com/storage/browser/archive-measurement-lab/](https://console.developers.google.com/storage/browser/archive-measurement-lab/){:target="_blank"}
 
 ## File Layout
 
@@ -44,11 +44,11 @@ $ gsutil cp gs://m-lab/ndt/2009/02/18/20090218T000000Z-mlab1-lga01-ndt-0000.tgz 
 
 ### Accessing Data With Common HTTP Tools
 
-The URLs shown in [M-Lab's GCS web interface](https://console.developers.google.com/storage/browser/m-lab/){:target="_blank"} require the user to be logged in, which can present challenges when attempting to access the data with common HTTP utilities like `curl` or `wget`.
+The URLs shown in [M-Lab's GCS web interface](https://console.developers.google.com/storage/browser/archive-measurement-lab/){:target="_blank"} require the user to be logged in, which can present challenges when attempting to access the data with common HTTP utilities like `curl` or `wget`.
 
 You can access M-Lab files programmatically by replacing:
 
-`storage.cloud.google.com/m/cloudstorage/b`
+`storage.cloud.google.com`
 
 with
 
@@ -58,23 +58,23 @@ in any GCS URL.
 
 For example, if the URL of a raw NDT archive on the GCS web application is:
 
-[https://storage.cloud.google.com/m/cloudstorage/b/m-lab/o/ndt/2015/12/28/20151228T000000Z-mlab1-lga04-ndt-0001.tgz](https://storage.cloud.google.com/m/cloudstorage/b/m-lab/o/ndt/2015/12/28/20151228T000000Z-mlab1-lga04-ndt-0001.tgz)
+[https://storage.cloud.google.com/archive-measurement-lab/ndt/2018/11/01/20181101T000001Z-mlab3-lga07-ndt-0000.tgz](https://storage.cloud.google.com/archive-measurement-lab/ndt/2018/11/01/20181101T000001Z-mlab3-lga07-ndt-0000.tgz)
 
 You can access it without authentication via this URL:
 
-[https://storage.googleapis.com/m-lab/ndt/2015/12/28/20151228T000000Z-mlab1-lga04-ndt-0001.tgz](https://storage.googleapis.com/m-lab/ndt/2015/12/28/20151228T000000Z-mlab1-lga04-ndt-0001.tgz)
+[https://storage.googleapis.com/archive-measurement-lab/ndt/2018/11/01/20181101T000001Z-mlab3-lga07-ndt-0000.tgz](https://storage.googleapis.com/archive-measurement-lab/ndt/2018/11/01/20181101T000001Z-mlab3-lga07-ndt-0000.tgz)
 
 ### GCS File Index
 
 A list of all M-Lab files in GCS is available at:
 
-[https://storage.googleapis.com/m-lab/list/all_mlab_tarfiles.txt.gz](https://storage.googleapis.com/m-lab/list/all_mlab_tarfiles.txt.gz)
+[https://storage.googleapis.com/archive-measurement-lab/list/all_mlab_tarfiles.txt.gz](https://storage.googleapis.com/archive-measurement-lab/list/all_mlab_tarfiles.txt.gz)
 
 This file provides gs:// URLs to M-Lab data.
 
 To change these URLs to https:// URLs (compatible with common HTTP tools), you can convert the file using the following [bash](https://en.wikipedia.org/wiki/Bash_%28Unix_shell%29) script:
 
 ~~~ shell
-$ curl https://storage.googleapis.com/m-lab/list/all_mlab_tarfiles.txt.gz | gunzip | \
+$ curl https://storage.googleapis.com/archive-measurement-lab/list/all_mlab_tarfiles.txt.gz | gunzip | \
 while read; do echo ${REPLY/gs:\/\//https://storage.googleapis.com/}; done
 ~~~

--- a/_pages/tests/glasnost.md
+++ b/_pages/tests/glasnost.md
@@ -13,7 +13,7 @@ Glasnost attempted to detect whether your Internet service provider (ISP) was pe
 
 Please cite this data set as follows: **The M-Lab Glasnost Data Set, &lt;date range used&gt;. https://measurementlab.net/tests/glasnost**
 
-**Data** collected by Glasnost is available in raw format at [https://console.cloud.google.com/storage/browser/m-lab/glasnost](https://console.cloud.google.com/storage/browser/m-lab/glasnost){:target="_blank"}.
+**Data** collected by Glasnost is available in raw format at [https://console.cloud.google.com/storage/browser/archive-measurement-lab/glasnost](https://console.cloud.google.com/storage/browser/archive-measurement-lab/glasnost){:target="_blank"}.
 
 **Data analysis code** is available at [http://code.google.com/p/glasnost/](http://code.google.com/p/glasnost/){:target="_blank"}.
 

--- a/_pages/tests/ndt.md
+++ b/_pages/tests/ndt.md
@@ -21,7 +21,7 @@ Please cite this data set as follows: **The M-Lab NDT Data Set, &lt;date range u
 
 **Data** collected by NDT is available:
 
-* in raw format at [https://console.cloud.google.com/storage/browser/m-lab/ndt](https://console.cloud.google.com/storage/browser/m-lab/ndt){:target="_blank"}.
+* in raw format at [https://console.cloud.google.com/storage/browser/archive-measurement-lab/ndt](https://console.cloud.google.com/storage/browser/archive-measurement-lab/ndt){:target="_blank"}.
 
 * in BigQuery at [https://www.measurementlab.net/data/bq/quickstart/]({{ site.baseurl }}/data/bq/quickstart/).
 

--- a/_pages/tests/neubot.md
+++ b/_pages/tests/neubot.md
@@ -9,11 +9,11 @@ breadcrumb: tests
 
 Neubot (the network neutrality bot) is a free software Internet bot, developed and maintained by the Nexa Center for Internet & Society, that gathers network performance data useful to investigate network neutrality. Once installed, it runs in the background and periodically performs active transmission tests with M-Lab servers. Three tests are currently implemented: "speedtest," which emulates HTTP; "bittorrent", which emulates BitTorrent; and "raw," which performs a raw TCP test.
 
-**[Download and run Neubot (Linux, MacOSX, and Windows**)](http://www.neubot.org/neubot-install-guide){:target="_blank"}
+**[Download and run Neubot (Linux, MacOSX, and Windows)](http://www.neubot.org/neubot-install-guide){:target="_blank"}
 
 Please cite this data set as follows: **The M-Lab Neubot Data Set, &lt;date range used&gt;. https://measurementlab.net/tests/neubot**
 
-**Data** collected by Neubot is available in raw format at [https://console.cloud.google.com/storage/browser/m-lab/neubot](https://console.cloud.google.com/storage/browser/m-lab/neubot){:target="_blank"} and at [http://www.neubot.org/data](http://www.neubot.org/data){:target="_blank"}.
+**Data** collected by Neubot is available in raw format at [https://console.cloud.google.com/storage/browser/archive-measurement-lab/neubot](https://console.cloud.google.com/storage/browser/archive-measurement-lab/neubot){:target="_blank"} and at [http://www.neubot.org/data](http://www.neubot.org/data){:target="_blank"}.
 
 **Source code** is available at [http://www.neubot.org/download](http://www.neubot.org/download){:target="_blank"}.
 

--- a/_pages/tests/npad.md
+++ b/_pages/tests/npad.md
@@ -13,7 +13,7 @@ Please cite this data set as follows: **The M-Lab NPAD Data Set, &lt;date range 
 
 **Data** collected by NPAD is available:
 
-* in raw format at [https://console.cloud.google.com/storage/browser/m-lab/npad](https://console.cloud.google.com/storage/browser/m-lab/npad){:target="_blank"}.
+* in raw format at [https://console.cloud.google.com/storage/browser/archive-measurement-lab/npad](https://console.cloud.google.com/storage/browser/archive-measurement-lab/npad){:target="_blank"}.
 
 * in BigQuery at [https://www.measurementlab.net/data/docs/bq/quickstart/]({{ site.baseurl }}/data/docs/bq/quickstart/).
 

--- a/_pages/tests/ooni.md
+++ b/_pages/tests/ooni.md
@@ -11,7 +11,7 @@ The Open Observatory of Network Interference (OONI) Probe is a groundbreaking an
 
 Please cite this data set as follows: **The M-Lab OONI Probe Data Set, &lt;date range used&gt;. https://measurementlab.net/tests/ooni
 
-**Data** collected by OONI Probe is available in raw format at [https://console.developers.google.com/storage/browser/m-lab/ooni/](https://console.developers.google.com/storage/browser/m-lab/ooni/){:target="_blank"}.
+**Data** collected by OONI Probe is available in raw format at [https://console.developers.google.com/storage/browser/archive-measurement-lab/ooni/](https://console.developers.google.com/storage/browser/archive-measurement-lab/ooni/){:target="_blank"}.
 
 **Source code** is available at [https://github.com/TheTorProject/ooni-probe](https://github.com/TheTorProject/ooni-probe){:target="_blank"}.
 

--- a/_pages/tests/paris_traceroute.md
+++ b/_pages/tests/paris_traceroute.md
@@ -13,8 +13,8 @@ Please cite this data set as follows: **The M-Lab Paris Traceroute Data Set, &lt
 
 **Data** collected by Paris Traceroute is available:
 
-* in raw format at [https://console.cloud.google.com/storage/browser/m-lab/paris-traceroute/](https://console.cloud.google.com/storage/browser/m-lab/paris-traceroute/){:target="_blank"}.
+* in raw format at [https://console.cloud.google.com/storage/browser/archive-measurement-lab/paris-traceroute/](https://console.cloud.google.com/storage/browser/archive-measurement-lab/paris-traceroute/){:target="_blank"}.
 
-* in BigQuery at [{{ site.baseurl }}/data/bq/quickstart/](http://www.measurementlab.net/data/bq/quickstart/).
+* in BigQuery at [{{ site.baseurl }}/data/bq/quickstart/]({{site.baseurl}}/data/bq/quickstart/).
 
 **Get more information** at [http://www.paris-traceroute.net](http://www.paris-traceroute.net/){:target="_blank"}.

--- a/_pages/tests/pathload2.md
+++ b/_pages/tests/pathload2.md
@@ -13,6 +13,6 @@ Pathload2 determined the available bandwidth of an Internet connection, in both 
 
 Please cite this data set as follows: **The M-Lab Pathload2 Data Set, &lt;date range used&gt;. https://measurementlab.net/tests/pathload2**
 
-**Data** collected by Pathload2 is available in raw format at [https://console.cloud.google.com/storage/browser/m-lab/pathload2](https://console.cloud.google.com/storage/browser/m-lab/pathload2){:target="_blank"}.
+**Data** collected by Pathload2 is available in raw format at [https://console.cloud.google.com/storage/browser/archive-measurement-lab/pathload2](https://console.cloud.google.com/storage/browser/archive-measurement-lab/pathload2){:target="_blank"}.
 
 **Source code** and **more information** is available at [https://code.google.com/p/pathload2-gatech/](https://code.google.com/p/pathload2-gatech/){:target="_blank"}.

--- a/_pages/tests/shaperprobe.md
+++ b/_pages/tests/shaperprobe.md
@@ -17,4 +17,4 @@ For any questions regarding the code/tool, please contact Partha Kanuparthy (kvb
 
 Please cite this data set as follows: **The M-Lab ShaperProbe Data Set, &lt;date range used&gt;. https://measurementlab.net/tests/shaperprobe**
 
-**Data** collected by ShaperProbe is available in raw format at [https://console.developers.google.com/storage/browser/m-lab/shaperprobe/](https://console.developers.google.com/storage/browser/m-lab/shaperprobe/){:target="_blank"}.
+**Data** collected by ShaperProbe is available in raw format at [https://console.developers.google.com/storage/browser/archive-measurement-lab/shaperprobe/](https://console.developers.google.com/storage/browser/archive-measurement-lab/shaperprobe/){:target="_blank"}.

--- a/_pages/tests/sidestream.md
+++ b/_pages/tests/sidestream.md
@@ -13,7 +13,7 @@ Please cite this data set as follows: **The M-Lab SideStream Data Set, &lt;date 
 
 **Data** collected by SideStream is available:
 
-* in raw format at [https://console.developers.google.com/storage/browser/m-lab/sidestream/](https://console.developers.google.com/storage/browser/m-lab/sidestream/).
+* in raw format at [https://console.developers.google.com/storage/browser/archive-measurement-lab/sidestream/](https://console.developers.google.com/storage/browser/archive-measurement-lab/sidestream/).
 
 * in BigQuery at [https://www.measurementlab.net/data/docs/bq/quickstart/]({{ site.baseurl }}/data/docs/bq/quickstart/).
 


### PR DESCRIPTION
This PR updates pages across the site with the new archive-measurement-lab storage bucket location. Also updates related documentation. One additional change on the publications page was also needed to build the site without error, since JSTOR now requires a login or accept link to be clicked. Linking directly to a PDF fails. @georgiamoon or @pboothe PTAL?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/m-lab.github.io/404)
<!-- Reviewable:end -->
