### PR TITLE
add 302 quickstart redirect

### DIFF
--- a/_pages/302-quickstart-redirect.md
+++ b/_pages/302-quickstart-redirect.md
@@ -1,0 +1,7 @@
+---
+layout: redirect
+permalink: /quickstart
+title: "Get Started with M-Lab Data"
+page-title: "Get Started with M-Lab Data"
+redirect_to: "https://measurementlab.net/data/docs/bq/quickstart/"
+---


### PR DESCRIPTION
adds a 302 redirect so /quickstart redirects people to the BQ quickstart guide