### PR TITLE
fix(deploy): sync sandbox/staging buckets with rsync and block crawlers

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,9 +23,16 @@ sass:
 include: ['_pages']
 exclude:
   - .gitignore
+  - AGENTS.md
+  - CONTRIBUTING.md
+  - Dockerfile
+  - Dockerfile.build
+  - LICENSE
   - README.md
   - Gemfile
   - Gemfile.lock
+  - cloudbuild.yaml
+  - firebase.json
   - _scripts
   - _site
   - vendor

--- a/_deploy/robots-nocrawl.txt
+++ b/_deploy/robots-nocrawl.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -56,8 +56,15 @@ steps:
     set -euo pipefail
     case "$$PROJECT_ID" in
       mlab-sandbox|mlab-staging)
-        gsutil -h 'Cache-Control:no-store' -m cp -r _site/* \
-          "gs://website.$$PROJECT_ID.measurementlab.net/"
+        # rsync -d mirrors _site/ exactly, deleting objects that are no longer
+        # in the built site (with cp -r, pages from long-deleted sandbox
+        # branches accumulated in the bucket forever). robots.txt exists only
+        # in these non-production buckets and is re-published after every
+        # sync so crawlers never index sandbox/staging.
+        gsutil -m -h 'Cache-Control:no-store' rsync -r -d _site \
+          "gs://website.$$PROJECT_ID.measurementlab.net"
+        gsutil -h 'Cache-Control:no-store' cp _deploy/robots-nocrawl.txt \
+          "gs://website.$$PROJECT_ID.measurementlab.net/robots.txt"
         ;;
       *)
         echo "Not a GCS-deploy project ($$PROJECT_ID); skipping."


### PR DESCRIPTION
Mirror the built site to the sandbox/staging GCS buckets instead of copying over them, and keep those environments out of search indexes.

- Replace `gsutil cp -r` with `gsutil rsync -r -d`, so objects deleted from the repo (or left behind by old sandbox branches) are removed from the bucket instead of accumulating forever.
- Publish a `robots.txt` disallowing all crawlers after every sync, so sandbox/staging never get indexed. The file only exists in these buckets, not in the repo's site source, so production is unaffected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/website/887)
<!-- Reviewable:end -->
